### PR TITLE
Catch null to prevent broken client

### DIFF
--- a/src/app/plan/PlanPageClient.tsx
+++ b/src/app/plan/PlanPageClient.tsx
@@ -12,7 +12,10 @@ import { StylishDatePicker } from "./StylishDatePicker";
 import { addDays, startOfDay } from "date-fns";
 
 export function PlanPageClient() {
-  const { data: plans = [] } = api.recipe.getMealPlans.useQuery();
+  const { data } = api.recipe.getMealPlans.useQuery();
+
+  // prevent null from cascading
+  const plans = data ?? [];
 
   const [shouldHideCompleted, setShouldHideCompleted] = useState(true);
 


### PR DESCRIPTION
PR includes:
* Add `??` to handle null data instead of relying on default value from destructuring

Did not confirm against prod database.  Reviewed prod data and could not spot problematic row.  There are 672 rows all returning recipe data, might be too many?