### PR TITLE
Add popular and recently made sections to main page

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "next lint",
     "start": "next start",
     "start-prod": "npm run init-bucket && npx prisma migrate deploy && NODE_ENV=production next start",
-    "init-bucket": "NODE_OPTIONS=--enable-source-maps node ./scripts/init-bucket.js"
+    "init-bucket": "NODE_OPTIONS=--enable-source-maps node ./scripts/init-bucket.js",
+    "format": "prettier --write src/**/*.{ts,tsx,js,jsx,json,css,md}"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^1.4.0",

--- a/prisma/migrations/20260206034648_add_purchase_recipe_link/migration.sql
+++ b/prisma/migrations/20260206034648_add_purchase_recipe_link/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "KrogerPurchase" ADD COLUMN     "recipeId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "KrogerPurchase" ADD CONSTRAINT "KrogerPurchase_recipeId_fkey" FOREIGN KEY ("recipeId") REFERENCES "Recipe"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model Recipe {
 
     PlannedMeal  PlannedMeal[]
     ShoppingList ShoppingList[]
+    KrogerPurchase KrogerPurchase[]
 
     // categorization
     type        RecipeType  @default(OTHER)
@@ -219,6 +220,10 @@ model KrogerPurchase {
     // optional link back to an ingredient (if purchase originated from a list item)
     ingredientId Int?
     ingredient   Ingredient? @relation(fields: [ingredientId], references: [id])
+
+    // optional link to recipe when ingredient is not known
+    recipeId Int?
+    Recipe   Recipe? @relation(fields: [recipeId], references: [id])
 
     // kroger specific details
     krogerSku       String // UPC

--- a/src/app/RecipeList.tsx
+++ b/src/app/RecipeList.tsx
@@ -149,7 +149,10 @@ export function RecipeList() {
                     (t) => t.slug === slug,
                   );
                   if (picked)
-                    setTags([...tags, { slug: picked.slug, name: picked.name }]);
+                    setTags([
+                      ...tags,
+                      { slug: picked.slug, name: picked.name },
+                    ]);
                 }}
               >
                 <SelectTrigger className="w-[200px]">

--- a/src/app/ingredients/IngredientsClient.tsx
+++ b/src/app/ingredients/IngredientsClient.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { IngredientPurchaseHistory } from "~/components/ingredients/IngredientPurchaseHistory";
+import { CardGrid } from "~/components/layout/CardGrid";
+import { Button } from "~/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "~/components/ui/command";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "~/components/ui/hover-card";
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
+import { api } from "~/trpc/react";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { cn } from "~/lib/utils";
+
+export function IngredientsClient() {
+  const { data, isLoading, error } = api.purchases.ingredientsCatalog.useQuery();
+  const [search, setSearch] = useState("");
+  const [recipeFilter, setRecipeFilter] = useState("all");
+  const [recipeFilterOpen, setRecipeFilterOpen] = useState(false);
+  const [aisleFilter, setAisleFilter] = useState("all");
+  const [purchaseFilter, setPurchaseFilter] = useState("all");
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(24);
+
+  const ingredients = useMemo(() => data ?? [], [data]);
+
+  const recipeOptions = useMemo(() => {
+    const seen = new Map<number, string>();
+    for (const ingredient of ingredients) {
+      for (const recipe of ingredient.recipes) {
+        seen.set(recipe.id, recipe.name);
+      }
+    }
+    return Array.from(seen.entries()).sort((a, b) =>
+      a[1].localeCompare(b[1], undefined, { sensitivity: "base" }),
+    );
+  }, [ingredients]);
+
+  const aisleOptions = useMemo(() => {
+    const seen = new Set<string>();
+    for (const ingredient of ingredients) {
+      if (ingredient.aisle?.trim()) {
+        seen.add(ingredient.aisle.trim());
+      }
+    }
+    return Array.from(seen).sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: "base" }),
+    );
+  }, [ingredients]);
+
+  const filteredIngredients = useMemo(() => {
+    const q = search.trim().toLowerCase();
+
+    return ingredients.filter((ingredient) => {
+      if (
+        recipeFilter !== "all" &&
+        !ingredient.recipes.some((recipe) => String(recipe.id) === recipeFilter)
+      ) {
+        return false;
+      }
+
+      if (aisleFilter !== "all") {
+        const ingredientAisle = ingredient.aisle?.trim().toLowerCase() ?? "";
+        if (ingredientAisle !== aisleFilter.toLowerCase()) {
+          return false;
+        }
+      }
+
+      if (purchaseFilter === "with" && ingredient.purchaseCount === 0) {
+        return false;
+      }
+
+      if (purchaseFilter === "without" && ingredient.purchaseCount > 0) {
+        return false;
+      }
+
+      if (!q) return true;
+
+      return (
+        ingredient.ingredient.toLowerCase().includes(q) ||
+        ingredient.recipes.some((recipe) =>
+          recipe.name.toLowerCase().includes(q),
+        ) ||
+        (ingredient.aisle ?? "").toLowerCase().includes(q)
+      );
+    });
+  }, [ingredients, search, recipeFilter, aisleFilter, purchaseFilter]);
+  const totalPages = Math.max(1, Math.ceil(filteredIngredients.length / pageSize));
+  const safePage = Math.min(page, totalPages);
+  const recipeFilterLabel =
+    recipeFilter === "all"
+      ? "All recipes"
+      : recipeOptions.find(([id]) => String(id) === recipeFilter)?.[1] ??
+        "All recipes";
+  const pagedIngredients = useMemo(
+    () =>
+      filteredIngredients.slice((safePage - 1) * pageSize, safePage * pageSize),
+    [filteredIngredients, pageSize, safePage],
+  );
+
+  if (isLoading) return <p>Loading ingredients...</p>;
+  if (error) return <p>Error loading ingredients.</p>;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <section className="rounded-2xl border bg-card/70 p-4 shadow-sm">
+        <div className="grid gap-3 lg:grid-cols-4">
+          <div className="flex flex-col gap-2 lg:col-span-2">
+            <Label className="text-xs uppercase text-muted-foreground">
+              Search
+            </Label>
+            <Input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Filter ingredients, recipes, or aisles"
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label className="text-xs uppercase text-muted-foreground">
+              Recipe
+            </Label>
+            <Popover open={recipeFilterOpen} onOpenChange={setRecipeFilterOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={recipeFilterOpen}
+                  className="h-9 w-full justify-between font-normal"
+                >
+                  <span className="truncate">{recipeFilterLabel}</span>
+                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-[360px] p-0" align="start">
+                <Command>
+                  <CommandInput placeholder="Filter recipes..." />
+                  <CommandList>
+                    <CommandEmpty>No recipes found.</CommandEmpty>
+                    <CommandItem
+                      value="All recipes"
+                      className="bg-accent/40 font-medium hover:bg-accent/60 data-[selected=true]:bg-accent/70"
+                      onSelect={() => {
+                        setRecipeFilter("all");
+                        setRecipeFilterOpen(false);
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          "mr-2 h-4 w-4",
+                          recipeFilter === "all" ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                      All recipes
+                    </CommandItem>
+                    {recipeOptions.map(([id, name]) => (
+                      <CommandItem
+                        key={id}
+                        value={name}
+                        onSelect={() => {
+                          setRecipeFilter(String(id));
+                          setRecipeFilterOpen(false);
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            "mr-2 h-4 w-4",
+                            recipeFilter === String(id)
+                              ? "opacity-100"
+                              : "opacity-0",
+                          )}
+                        />
+                        <span className="truncate">{name}</span>
+                      </CommandItem>
+                    ))}
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label className="text-xs uppercase text-muted-foreground">
+              Aisle
+            </Label>
+            <Select value={aisleFilter} onValueChange={setAisleFilter}>
+              <SelectTrigger className="h-9">
+                <SelectValue placeholder="All aisles" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All aisles</SelectItem>
+                {aisleOptions.map((aisle) => (
+                  <SelectItem key={aisle} value={aisle}>
+                    {aisle}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+          <ToggleGroup
+            type="single"
+            value={purchaseFilter}
+            onValueChange={(value) => {
+              if (value) setPurchaseFilter(value);
+            }}
+            variant="outline"
+            size="sm"
+            className="flex flex-wrap justify-start gap-2"
+          >
+            <ToggleGroupItem value="all">All</ToggleGroupItem>
+            <ToggleGroupItem value="with">With purchases</ToggleGroupItem>
+            <ToggleGroupItem value="without">No purchases yet</ToggleGroupItem>
+          </ToggleGroup>
+          <span className="text-xs text-muted-foreground">
+            {filteredIngredients.length} ingredients
+          </span>
+        </div>
+      </section>
+
+      <CardGrid className="md:grid-cols-2 xl:grid-cols-3">
+        {pagedIngredients.map((ingredient) => (
+          <section
+            key={ingredient.id}
+            className="flex min-h-[220px] flex-col rounded-2xl border bg-card/70 p-3.5 shadow-sm"
+          >
+            <p className="text-base font-semibold">{ingredient.ingredient}</p>
+            <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+              <span className="rounded-full bg-background/80 px-2 py-0.5 text-muted-foreground">
+                {ingredient.aisle?.trim() ?? "Unknown aisle"}
+              </span>
+              <span className="rounded-full bg-background/80 px-2 py-0.5 text-muted-foreground">
+                {ingredient.purchaseCount} purchases
+              </span>
+            </div>
+
+            <div className="mt-3 flex-1 pb-2">
+              <IngredientPurchaseHistory
+                purchases={ingredient.recentPurchases}
+                compact
+                hideEmpty
+              />
+            </div>
+
+            <div className="mt-auto min-h-[96px] border-t border-border/60 pt-3.5">
+              <div className="space-y-1.5">
+                {ingredient.recipes.slice(0, 2).map((recipe) => (
+                  <Link
+                    key={recipe.id}
+                    href={`/recipes/${recipe.id}`}
+                    className="block rounded-md bg-accent/50 px-2 py-1 text-sm font-medium hover:bg-accent/70"
+                    title={recipe.name}
+                  >
+                    <span className="block truncate">{recipe.name}</span>
+                  </Link>
+                ))}
+                {ingredient.recipes.length > 2 ? (
+                  <HoverCard openDelay={90}>
+                    <HoverCardTrigger className="rounded-full bg-background/80 px-2 py-0.5 text-xs text-muted-foreground">
+                      +{ingredient.recipes.length - 2} more recipes
+                    </HoverCardTrigger>
+                    <HoverCardContent
+                      align="start"
+                      className="w-64 rounded-2xl border bg-card p-3 shadow-xl"
+                    >
+                      <p className="mb-2 text-xs uppercase text-muted-foreground">
+                        Other recipes
+                      </p>
+                      <div className="flex flex-col gap-1.5">
+                        {ingredient.recipes.slice(2).map((recipe) => (
+                          <Link
+                            key={recipe.id}
+                            href={`/recipes/${recipe.id}`}
+                            className="truncate rounded-md px-2 py-1 text-sm hover:bg-accent/40"
+                            title={recipe.name}
+                          >
+                            {recipe.name}
+                          </Link>
+                        ))}
+                      </div>
+                    </HoverCardContent>
+                  </HoverCard>
+                ) : null}
+              </div>
+            </div>
+          </section>
+        ))}
+      </CardGrid>
+
+      {pagedIngredients.length === 0 ? (
+        <section className="rounded-2xl border bg-card/70 p-6 text-sm text-muted-foreground shadow-sm">
+          No ingredients match your filters.
+        </section>
+      ) : null}
+      {filteredIngredients.length > 0 ? (
+        <section className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border bg-card/70 px-4 py-3 text-sm shadow-sm">
+          <span className="text-muted-foreground">
+            Showing {(safePage - 1) * pageSize + 1}–
+            {Math.min(safePage * pageSize, filteredIngredients.length)} of{" "}
+            {filteredIngredients.length}
+          </span>
+          <div className="flex items-center gap-2">
+            <Select
+              value={String(pageSize)}
+              onValueChange={(value) => {
+                setPageSize(Number(value));
+                setPage(1);
+              }}
+            >
+              <SelectTrigger className="h-8 w-[110px] text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {["12", "24", "36", "60"].map((size) => (
+                  <SelectItem key={size} value={size}>
+                    {size} / page
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <button
+              className="rounded-md border px-2 py-1 text-xs disabled:opacity-50"
+              disabled={safePage === 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+            >
+              Prev
+            </button>
+            <span className="text-xs text-muted-foreground">
+              Page {safePage} of {totalPages}
+            </span>
+            <button
+              className="rounded-md border px-2 py-1 text-xs disabled:opacity-50"
+              disabled={safePage === totalPages}
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            >
+              Next
+            </button>
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/ingredients/page.tsx
+++ b/src/app/ingredients/page.tsx
@@ -1,0 +1,22 @@
+import { PageHeaderCard } from "~/components/layout/PageHeaderCard";
+import { H1 } from "~/components/ui/typography";
+import { useEnforceAuth } from "../useEnforceAuth";
+import { helpers } from "~/trpc/helpers";
+import { IngredientsClient } from "./IngredientsClient";
+
+export default async function IngredientsPage() {
+  await useEnforceAuth();
+  await (await helpers()).purchases.ingredientsCatalog.prefetch();
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <PageHeaderCard className="border-0 bg-transparent p-0 shadow-none">
+        <div className="flex flex-col">
+          <H1 className="leading-tight">Ingredients</H1>
+        </div>
+      </PageHeaderCard>
+
+      <IngredientsClient />
+    </div>
+  );
+}

--- a/src/app/list/ShoppingListCard.tsx
+++ b/src/app/list/ShoppingListCard.tsx
@@ -12,15 +12,19 @@ import { getIngredientLabel } from "./getIngredientLabel";
 import { SimpleAlertDialog } from "~/components/SimpleAlertDialog";
 import { AislePickerDialog } from "./AislePickerDialog";
 import { TooltipButton } from "~/components/ui/tooltip-button";
+import { IngredientPurchaseHistory } from "~/components/ingredients/IngredientPurchaseHistory";
 
 export type ShoppingListItem =
   RouterOutputs["shoppingList"]["getShoppingList"][0];
+type RecentPurchase =
+  RouterOutputs["purchases"]["recentByIngredientIds"]["ingredientPurchases"][number]["purchases"][number];
 
 export function ShoppingListCard(props: {
   item: ShoppingListItem;
   displayMode: "recipe" | "aisle";
+  recentPurchases: RecentPurchase[];
 }) {
-  const { item } = props;
+  const { item, recentPurchases } = props;
 
   const { handleDeleteItem, handleMarkAsBought } = useShoppingListActions();
 
@@ -68,6 +72,16 @@ export function ShoppingListCard(props: {
             isBought && "invisible",
           )}
         >
+          {item.ingredient && recentPurchases.length > 0 ? (
+            <IngredientPurchaseHistory
+              purchases={recentPurchases}
+              currentRecipeId={item.Recipe?.id}
+              ingredientId={item.ingredient.id}
+              listItemId={item.id}
+              compact
+              hideEmpty
+            />
+          ) : null}
           <KrogerSearchPopup
             originalListItemId={item.id}
             ingredient={item.ingredient?.ingredient}

--- a/src/app/plan/PlanPageClient.tsx
+++ b/src/app/plan/PlanPageClient.tsx
@@ -1,93 +1,214 @@
 "use client";
 
-import { H1 } from "~/components/ui/typography";
-import { api } from "~/trpc/react";
-import { useRecipeActions } from "../useRecipeActions";
-import { PlanCard } from "./PlanCard";
-import { RecipePickerPopover } from "./RecipePickerPopover";
-import { useEffect, useState } from "react";
-import { Switch } from "~/components/ui/switch";
-import { Label } from "~/components/ui/label";
-import { StylishDatePicker } from "./StylishDatePicker";
-import { addDays, startOfDay } from "date-fns";
-import { CardGrid } from "~/components/layout/CardGrid";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import {
+  addDays,
+  endOfDay,
+  format,
+  isToday,
+  startOfDay,
+  startOfWeek,
+} from "date-fns";
+import { CalendarDays, ShoppingBasket, Trash } from "lucide-react";
+
 import { PageHeaderCard } from "~/components/layout/PageHeaderCard";
+import { Button } from "~/components/ui/button";
+import { Calendar } from "~/components/ui/calendar";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "~/components/ui/hover-card";
+import { Label } from "~/components/ui/label";
+import { Switch } from "~/components/ui/switch";
+import { TooltipButton } from "~/components/ui/tooltip-button";
+import { H1 } from "~/components/ui/typography";
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
+import { cn } from "~/lib/utils";
+import { api, type RouterOutputs } from "~/trpc/react";
+import { useMealPlanActions } from "../useMealPlanActions";
+import { useRecipeActions } from "../useRecipeActions";
+import { RecipePickerPopover } from "./RecipePickerPopover";
+
+type PlannedMealWithRecipe = RouterOutputs["recipe"]["getMealPlans"][0];
+
+const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function MealPlanRow(props: {
+  plan: PlannedMealWithRecipe;
+  onDelete: (id: number) => void;
+  onToggleMade: (plan: PlannedMealWithRecipe) => void;
+  onAddToList: (id: number) => Promise<unknown>;
+  onReschedule: (plan: PlannedMealWithRecipe, date: Date) => Promise<unknown>;
+  isMutating: boolean;
+}) {
+  const { plan, onDelete, onToggleMade, onAddToList, onReschedule, isMutating } =
+    props;
+  const [isHoverOpen, setIsHoverOpen] = useState(false);
+  const [isMovePopoverOpen, setIsMovePopoverOpen] = useState(false);
+
+  return (
+    <HoverCard
+      openDelay={70}
+      closeDelay={120}
+      open={isHoverOpen || isMovePopoverOpen}
+      onOpenChange={setIsHoverOpen}
+    >
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "w-full truncate px-0 py-0.5 text-left text-sm font-medium transition-colors hover:text-foreground/80",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+            plan.isMade && "text-muted-foreground",
+          )}
+        >
+          {plan.Recipe.name}
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent
+        align="start"
+        side="right"
+        className="w-72 overflow-visible p-0"
+      >
+        <div className="space-y-3 p-4">
+          <div className="space-y-2">
+            <Link
+              href={`/recipes/${plan.Recipe.id}`}
+              className="line-clamp-2 text-base font-semibold leading-tight hover:underline"
+            >
+              {plan.Recipe.name}
+            </Link>
+            <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+              <span className="rounded-full border px-2 py-0.5">{plan.Recipe.type}</span>
+              {plan.isMade && <span className="rounded-full bg-muted px-2 py-0.5">made</span>}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between border-t pt-3">
+            <div className="flex items-center gap-2">
+              <TooltipButton content="Delete meal">
+                <Button
+                  onClick={() => onDelete(plan.id)}
+                  variant="destructive-outline"
+                  size="icon"
+                  aria-label="Delete meal"
+                >
+                  <Trash className="h-4 w-4 shrink-0" />
+                </Button>
+              </TooltipButton>
+
+              <TooltipButton
+                content={plan.isOnShoppingList ? "Already on list" : "Add to list"}
+              >
+                <Button
+                  onClick={() => {
+                    void onAddToList(plan.id);
+                  }}
+                  disabled={isMutating || plan.isOnShoppingList}
+                  size="icon"
+                  variant="outline"
+                  aria-label="Add to list"
+                >
+                  <ShoppingBasket className="h-4 w-4 shrink-0" />
+                </Button>
+              </TooltipButton>
+
+              <Popover open={isMovePopoverOpen} onOpenChange={setIsMovePopoverOpen}>
+                <PopoverTrigger asChild>
+                  <span className="inline-flex">
+                    <TooltipButton content="Move to another day">
+                      <Button
+                        disabled={isMutating}
+                        size="icon"
+                        variant="outline"
+                        aria-label="Move meal to another day"
+                      >
+                        <CalendarDays className="h-4 w-4 shrink-0" />
+                      </Button>
+                    </TooltipButton>
+                  </span>
+                </PopoverTrigger>
+                <PopoverContent side="right" align="start" className="w-auto p-2">
+                  <Calendar
+                    mode="single"
+                    selected={plan.date}
+                    onSelect={async (date) => {
+                      if (!date) return;
+                      await onReschedule(plan, startOfDay(date));
+                      setIsMovePopoverOpen(false);
+                    }}
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+
+            <Button
+              onClick={() => onToggleMade(plan)}
+              disabled={isMutating}
+              size="sm"
+              className="h-8"
+            >
+              {plan.isMade ? "Not made" : "Made"}
+            </Button>
+          </div>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
 
 export function PlanPageClient() {
   const { data } = api.recipe.getMealPlans.useQuery();
 
-  // prevent null from cascading
-  const plans = data ?? [];
-
   const [shouldHideCompleted, setShouldHideCompleted] = useState(true);
 
-  // TODO: this filtering should be done on the server
-  const _plansThisMonth = plans
-    .filter((plan) => {
-      // filter within -14 days and +14 days
-      const date = new Date(plan.date);
-      const now = new Date();
-      const fourteenDaysAgo = new Date();
-      fourteenDaysAgo.setDate(now.getDate() - 14);
-      const fourteenDaysFromNow = new Date();
-      fourteenDaysFromNow.setDate(now.getDate() + 14);
+  const { handleDelete } = useMealPlanActions();
+  const { handleAddToMealPlan, addMealPlanToList } = useRecipeActions();
+  const updatePlan = api.mealPlan.updateMealPlan.useMutation();
 
-      return date >= fourteenDaysAgo && date <= fourteenDaysFromNow;
-    })
-    .filter((plan) => (!shouldHideCompleted ? true : !plan.isMade));
+  const today = startOfDay(new Date());
+  const calendarStart = startOfWeek(today, { weekStartsOn: 0 });
+  const calendarEnd = endOfDay(addDays(calendarStart, 20));
 
-  // sort by date
-  const plansThisMonth = _plansThisMonth.sort((a, b) => {
-    // verify they are dates
-    if (!a?.date || !b?.date) {
-      return 0;
-    }
-
-    // type guard for dates
-    if (!(a.date instanceof Date) || !(b.date instanceof Date)) {
-      return 0;
-    }
-
-    return a?.date?.getTime() - b?.date?.getTime();
-  });
-
-  const { handleAddToMealPlan } = useRecipeActions();
-
-  // get the maximum date of the plans + 1 day (or current date, whichever is later)
-  // this is the default date for the date picker
-
-  const maxDate = plans.reduce(
-    (max, plan) => {
-      const date = addDays(plan.date, 1);
-
-      return date > max ? date : max;
-    },
-    addDays(new Date(), 1),
+  const calendarDays = useMemo(
+    () => Array.from({ length: 21 }, (_, index) => addDays(calendarStart, index)),
+    [calendarStart],
   );
 
-  const dateString = maxDate?.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
+  const visiblePlans = useMemo(() => {
+    return (data ?? [])
+      .filter((plan) => {
+        const planDate = plan.date;
+        return planDate >= calendarStart && planDate <= calendarEnd;
+      })
+      .filter((plan) => (!shouldHideCompleted ? true : !plan.isMade))
+      .sort((a, b) => a.date.getTime() - b.date.getTime());
+  }, [calendarEnd, calendarStart, data, shouldHideCompleted]);
 
-  const [newDate, setNewDate] = useState<Date | undefined>(maxDate);
+  const plansByDay = useMemo(() => {
+    const map = new Map<string, PlannedMealWithRecipe[]>();
 
-  useEffect(() => {
-    if (!maxDate) return;
+    for (const plan of visiblePlans) {
+      const key = format(startOfDay(plan.date), "yyyy-MM-dd");
+      const current = map.get(key);
+      if (!current) {
+        map.set(key, [plan]);
+        continue;
+      }
+      current.push(plan);
+    }
 
-    // set the date to the next day if the date is in the past
-    setNewDate(maxDate);
-
-    // this is the string to avoid an infinite loop
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dateString]);
+    return map;
+  }, [visiblePlans]);
 
   return (
-    <div className="flex flex-col gap-4">
-      <PageHeaderCard className="p-5">
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <H1>Planned Meals</H1>
-          <div className="flex items-center gap-2 rounded-full border bg-background/80 px-3 py-2">
+    <div className="flex flex-col gap-5">
+      <PageHeaderCard className="border-0 bg-transparent p-0 shadow-none">
+        <div className="flex flex-col gap-3">
+          <H1 className="leading-tight">Planned Meals</H1>
+          <div className="flex items-center gap-2">
             <Switch
               checked={shouldHideCompleted}
               onCheckedChange={setShouldHideCompleted}
@@ -100,28 +221,81 @@ export function PlanPageClient() {
         </div>
       </PageHeaderCard>
 
-      <CardGrid className="sm:grid-cols-2 lg:grid-cols-3">
-        {plansThisMonth.map((plan) => (
-          <PlanCard key={plan.id} plan={plan} />
+      <div className="hidden gap-2 md:grid md:grid-cols-7">
+        {WEEKDAY_LABELS.map((day) => (
+          <div
+            key={day}
+            className="px-2 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            {day}
+          </div>
         ))}
+      </div>
 
-        <div className="flex h-full min-h-[190px] flex-col gap-3 rounded-2xl border bg-card/70 p-3 shadow-sm">
-          <div className="flex items-start gap-3">
-            <StylishDatePicker value={newDate} onChange={setNewDate} />
-            <div className="min-h-[76px] flex-1" />
-          </div>
-          <div className="mt-auto flex items-center justify-between gap-2 border-t pt-2">
-            <RecipePickerPopover
-              onRecipeSelected={async (recipeId) => {
-                await handleAddToMealPlan(
-                  recipeId,
-                  startOfDay(newDate ?? new Date()),
-                );
-              }}
-            />
-          </div>
-        </div>
-      </CardGrid>
+      <div className="grid grid-cols-1 gap-2 md:grid-cols-7">
+        {calendarDays.map((day) => {
+          const dayKey = format(day, "yyyy-MM-dd");
+          const dayPlans = plansByDay.get(dayKey) ?? [];
+          const isCurrentDay = isToday(day);
+
+          return (
+            <div
+              key={dayKey}
+              className={cn(
+                "flex min-h-[170px] flex-col gap-2 rounded-2xl border bg-card/70 p-3 shadow-sm",
+                isCurrentDay && "border-primary/70 bg-primary/5",
+              )}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="text-lg font-semibold leading-none">
+                    {format(day, "d")}
+                  </span>
+                  <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                    {format(day, "MMM")}
+                  </span>
+                  <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground md:hidden">
+                    {format(day, "EEE")}
+                  </span>
+                </div>
+              </div>
+
+              <div className="flex flex-1 flex-col gap-1">
+                {dayPlans.map((plan) => (
+                  <MealPlanRow
+                    key={plan.id}
+                    plan={plan}
+                    onDelete={handleDelete}
+                    onToggleMade={(selectedPlan) => {
+                      updatePlan.mutate({
+                        id: selectedPlan.id,
+                        isMade: !selectedPlan.isMade,
+                      });
+                    }}
+                    onAddToList={(id) => addMealPlanToList.mutateAsync({ id })}
+                    onReschedule={(selectedPlan, date) =>
+                      updatePlan.mutateAsync({
+                        id: selectedPlan.id,
+                        date,
+                      })
+                    }
+                    isMutating={updatePlan.isPending || addMealPlanToList.isPending}
+                  />
+                ))}
+              </div>
+
+              <div className="mt-auto flex justify-center pt-1">
+                <RecipePickerPopover
+                  iconOnly
+                  onRecipeSelected={async (recipeId) => {
+                    await handleAddToMealPlan(recipeId, startOfDay(day));
+                  }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/app/plan/RecipePickerPopover.tsx
+++ b/src/app/plan/RecipePickerPopover.tsx
@@ -19,6 +19,7 @@ import {
 
 export function RecipePickerPopover(props: {
   onRecipeSelected: (recipeId: number) => void;
+  iconOnly?: boolean;
 }) {
   const { data: recipes = [] } = api.recipe.getRecipes.useQuery();
 
@@ -69,10 +70,21 @@ export function RecipePickerPopover(props: {
         <PopoverTrigger asChild>
           <span className="inline-flex">
             <TooltipButton content="Add meal">
-              <Button variant="outline" className="h-10 rounded-full">
-                <Plus className="h-4 w-4" />
-                Add meal
-              </Button>
+              {props.iconOnly ? (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Add meal"
+                  className="text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                >
+                  <Plus className="h-4 w-4 shrink-0" />
+                </Button>
+              ) : (
+                <Button variant="outline" className="h-10 rounded-full">
+                  <Plus className="h-4 w-4 shrink-0" />
+                  Add meal
+                </Button>
+              )}
             </TooltipButton>
           </span>
         </PopoverTrigger>

--- a/src/app/purchases/PurchasesList.tsx
+++ b/src/app/purchases/PurchasesList.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { api } from "~/trpc/react";
 import { formatMoney } from "../list/formatMoney";
+import Link from "next/link";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import {
@@ -158,64 +159,79 @@ export function PurchasesList() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {pagedPurchases.map((purchase) => (
-              <TableRow key={purchase.id}>
-                <TableCell className="py-3">
-                  <div className="flex items-center gap-3">
-                    <img
-                      src={purchase.imageUrl}
-                      alt={purchase.krogerName}
-                      className="h-12 w-12 rounded-md object-cover"
-                    />
-                    <div>
-                      <div className="font-semibold">
-                        {purchase.krogerName}
-                      </div>
-                      <div className="text-xs text-muted-foreground">
-                        {[purchase.krogerBrand, purchase.krogerSku, purchase.krogerProductId, purchase.itemSize]
-                          .filter(Boolean)
-                          .join(" • ")}
-                      </div>
-                      {purchase.ingredient && (
+            {pagedPurchases.map((purchase) => {
+              const linkedRecipe = purchase.linkedRecipe;
+
+              return (
+                <TableRow key={purchase.id}>
+                  <TableCell className="py-3">
+                    <div className="flex items-center gap-3">
+                      <img
+                        src={purchase.imageUrl}
+                        alt={purchase.krogerName}
+                        className="h-12 w-12 rounded-md object-cover"
+                      />
+                      <div>
+                        <div className="font-semibold">
+                          {purchase.krogerName}
+                        </div>
                         <div className="text-xs text-muted-foreground">
-                          From ingredient: {purchase.ingredient.ingredient}
+                          {[purchase.krogerBrand, purchase.krogerSku, purchase.krogerProductId, purchase.itemSize]
+                            .filter(Boolean)
+                            .join(" • ")}
                         </div>
-                      )}
-                      {purchase.note && (
-                        <div className="text-xs text-destructive">
-                          Note: {purchase.note}
-                        </div>
-                      )}
+                        {purchase.ingredientName && (
+                          <div className="text-xs text-muted-foreground">
+                            From ingredient: {purchase.ingredientName}
+                          </div>
+                        )}
+                        {linkedRecipe && (
+                          <div className="text-xs text-muted-foreground">
+                            Recipe:{" "}
+                            <Link
+                              href={`/recipes/${linkedRecipe.id}`}
+                              className="font-medium text-foreground underline-offset-2 hover:underline"
+                            >
+                              {linkedRecipe.name}
+                            </Link>
+                          </div>
+                        )}
+                        {purchase.note && (
+                          <div className="text-xs text-destructive">
+                            Note: {purchase.note}
+                          </div>
+                        )}
+                      </div>
                     </div>
-                  </div>
-                </TableCell>
-                <TableCell className="py-3 text-sm">
-                  <div className="font-semibold">
-                    {formatMoney(purchase.price)} × {purchase.quantity}
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    Total {formatMoney(purchase.price * purchase.quantity)}
-                  </div>
-                </TableCell>
-                <TableCell className="py-3 text-sm">
-                  <span
-                    className={`rounded-full px-2 py-0.5 text-xs ${
-                      purchase.wasAddedToCart
-                        ? "bg-emerald-100 text-emerald-700"
-                        : "bg-muted text-muted-foreground"
-                    }`}
-                  >
-                    {purchase.wasAddedToCart ? "Added" : "Attempted"}
-                  </span>
-                </TableCell>
-                <TableCell className="py-3 text-xs text-muted-foreground">
-                  {purchase.krogerCategories?.[0] ?? "—"}
-                </TableCell>
-                <TableCell className="py-3 text-right text-xs text-muted-foreground">
-                  {new Date(purchase.createdAt).toLocaleString()}
-                </TableCell>
-              </TableRow>
-            ))}
+                  </TableCell>
+                  <TableCell className="py-3 text-sm">
+                    <div className="font-semibold">
+                      {formatMoney(purchase.price)} × {purchase.quantity}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      Total {formatMoney(purchase.price * purchase.quantity)}
+                    </div>
+                  </TableCell>
+                  <TableCell className="py-3 text-sm">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs ${
+                        purchase.wasAddedToCart
+                          ? "bg-emerald-100 text-emerald-700"
+                          : "bg-muted text-muted-foreground"
+                      }`}
+                    >
+                      {purchase.wasAddedToCart ? "Added" : "Attempted"}
+                    </span>
+                  </TableCell>
+                  <TableCell className="py-3 text-xs text-muted-foreground">
+                    {purchase.krogerCategories?.[0] ?? "—"}
+                  </TableCell>
+                  <TableCell className="py-3 text-right text-xs text-muted-foreground">
+                    {new Date(purchase.createdAt).toLocaleString()}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
         {filteredPurchases.length === 0 && (

--- a/src/app/recipes/[id]/IngredientList.tsx
+++ b/src/app/recipes/[id]/IngredientList.tsx
@@ -1,35 +1,65 @@
 "use client";
 
 import { Ban, Edit } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { H3, H4 } from "~/components/ui/typography";
 import { IngredientListEditMode } from "./IngredientListEditMode";
 import { type Recipe } from "./recipe-types";
+import { IngredientPurchaseHistory } from "~/components/ingredients/IngredientPurchaseHistory";
+import { api, type RouterOutputs } from "~/trpc/react";
+
+type RecentPurchase =
+  RouterOutputs["purchases"]["recentByIngredientIds"]["ingredientPurchases"][number]["purchases"][number];
 
 export interface IngredientListProps {
   recipe: Recipe;
 }
 export function IngredientList({ recipe }: IngredientListProps) {
   const [isEditing, setIsEditing] = useState(false);
+  const { data: ingredientsCatalog } = api.purchases.ingredientsCatalog.useQuery();
+  const purchasesByIngredientName = useMemo(() => {
+    const m = new Map<string, RecentPurchase[]>();
+    for (const ingredient of ingredientsCatalog ?? []) {
+      m.set(ingredient.ingredient.trim().toLowerCase(), ingredient.recentPurchases);
+    }
+    return m;
+  }, [ingredientsCatalog]);
 
   const mainComp = (
     <ul>
       {recipe.ingredientGroups.map((ingredient, idx) => (
         <div key={ingredient.id ?? idx} className="space-y-1">
           <H4>{ingredient.title}</H4>
-          {ingredient.ingredients.map((i) => (
-            <div key={i.id ?? `${ingredient.id ?? idx}-${i.ingredient}`} className="flex items-center gap-2">
-              <label
-                className="flex gap-1 break-words text-lg"
-                htmlFor={`ingredient-${i.id}`}
+          {ingredient.ingredients.map((i) => {
+            const purchaseHistory =
+              purchasesByIngredientName.get(i.ingredient.trim().toLowerCase()) ??
+              [];
+
+            return (
+              <div
+                key={i.id ?? `${ingredient.id ?? idx}-${i.ingredient}`}
+                className="flex items-center justify-between gap-3"
               >
-                {[i.amount, i.unit, i.ingredient, i.modifier]
-                  .filter(Boolean)
-                  .join(" ")}
-              </label>
-            </div>
-          ))}
+                <label
+                  className="flex min-w-0 flex-1 gap-1 break-words text-lg"
+                  htmlFor={`ingredient-${i.id}`}
+                >
+                  {[i.amount, i.unit, i.ingredient, i.modifier]
+                    .filter(Boolean)
+                    .join(" ")}
+                </label>
+                <IngredientPurchaseHistory
+                  purchases={purchaseHistory}
+                  compact
+                  hideEmpty
+                  currentRecipeId={recipe.id}
+                  ingredientId={i.id}
+                  className="shrink-0"
+                />
+              </div>
+            );
+          })}
         </div>
       ))}
     </ul>

--- a/src/app/recipes/[id]/RecipeRecentPurchasesSection.tsx
+++ b/src/app/recipes/[id]/RecipeRecentPurchasesSection.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { IngredientPurchaseHistory } from "~/components/ingredients/IngredientPurchaseHistory";
+import { Label } from "~/components/ui/label";
+import { type Recipe } from "./recipe-types";
+import { api } from "~/trpc/react";
+
+function ingredientLabel(ingredient: {
+  amount: string;
+  unit: string;
+  ingredient: string;
+  modifier: string;
+}) {
+  return [
+    ingredient.amount,
+    ingredient.unit,
+    ingredient.ingredient,
+    ingredient.modifier,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+export function RecipeRecentPurchasesSection(props: { recipe: Recipe }) {
+  const { recipe } = props;
+  const ingredients = recipe.ingredientGroups.flatMap((group) =>
+    group.ingredients.map((ingredient) => ({
+      id: ingredient.id,
+      label: ingredientLabel(ingredient),
+    })),
+  );
+  const ingredientIds = ingredients.map((ingredient) => ingredient.id);
+
+  const { data: recentByIngredient } = api.purchases.recentByIngredientIds.useQuery(
+    { ingredientIds, limit: 3 },
+    { enabled: ingredientIds.length > 0 },
+  );
+
+  const purchasesByIngredient = new Map(
+    (recentByIngredient?.ingredientPurchases ?? []).map((entry) => [
+      entry.ingredientId,
+      entry.purchases,
+    ]),
+  );
+
+  const ingredientsWithHistory = ingredients.filter((ingredient) => {
+    const purchases = purchasesByIngredient.get(ingredient.id) ?? [];
+    return purchases.length > 0;
+  });
+
+  return (
+    <section className="rounded-2xl border bg-card/70 p-4 shadow-sm">
+      <div className="flex items-center justify-between gap-2">
+        <Label className="text-xs uppercase text-muted-foreground">
+          Recent purchases
+        </Label>
+        <span className="text-xs text-muted-foreground">
+          {ingredientsWithHistory.length} ingredients with history
+        </span>
+      </div>
+
+      {ingredientsWithHistory.length === 0 ? (
+        <p className="mt-2 text-sm text-muted-foreground">
+          No purchases yet for this recipe.
+        </p>
+      ) : (
+        <div className="mt-3 grid gap-2 md:grid-cols-2">
+          {ingredientsWithHistory.map((ingredient) => (
+            <div
+              key={ingredient.id}
+              className="rounded-xl border bg-background/70 px-3 py-2"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <p className="truncate text-sm font-semibold">{ingredient.label}</p>
+                <IngredientPurchaseHistory
+                  purchases={purchasesByIngredient.get(ingredient.id) ?? []}
+                  currentRecipeId={recipe.id}
+                  ingredientId={ingredient.id}
+                  compact
+                  hideEmpty
+                  className="shrink-0"
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app/recipes/new/NewRecipeDialog.tsx
+++ b/src/app/recipes/new/NewRecipeDialog.tsx
@@ -8,6 +8,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -26,9 +27,12 @@ export function NewRecipeDialog() {
         </Button>
       </DialogTrigger>
 
-      <DialogContent className="grid h-[90vh] max-h-[90vh] max-w-5xl grid-rows-[auto,1fr,auto] overflow-hidden">
+      <DialogContent className="grid max-h-[90vh] max-w-4xl grid-rows-[auto,1fr,auto] gap-3 overflow-hidden p-5">
         <DialogHeader>
           <DialogTitle>Create New Recipe</DialogTitle>
+          <DialogDescription>
+            Add details, tags, ingredients, and steps.
+          </DialogDescription>
         </DialogHeader>
 
         <NewRecipeForm
@@ -38,11 +42,11 @@ export function NewRecipeDialog() {
 
         <DialogFooter>
           <DialogClose asChild>
-            <Button variant="secondary">Cancel</Button>
+            <Button variant="outline">Cancel</Button>
           </DialogClose>
-          <Button type="submit" form={formId} disabled={isSubmitting}>
+          <Button type="submit" form={formId} isLoading={isSubmitting}>
             <Plus />
-            Create Recipe!
+            Create recipe
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/MainPageWithNav.tsx
+++ b/src/components/MainPageWithNav.tsx
@@ -27,6 +27,9 @@ export async function MainPageWithNav(props: { children: React.ReactNode }) {
               <NavLink href="/purchases" className="text-lg">
                 purchases
               </NavLink>
+              <NavLink href="/ingredients" className="text-lg">
+                ingredients
+              </NavLink>
               <NavLink href="/ai/recipe" className="text-lg">
                 ai
               </NavLink>
@@ -35,7 +38,9 @@ export async function MainPageWithNav(props: { children: React.ReactNode }) {
               </NavLink>
             </>
           ) : (
-            <div className="px-3 py-1 text-lg font-semibold">family recipes</div>
+            <div className="px-3 py-1 text-lg font-semibold">
+              family recipes
+            </div>
           )}
         </div>
 

--- a/src/components/ingredients/IngredientPurchaseHistory.tsx
+++ b/src/components/ingredients/IngredientPurchaseHistory.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { formatMoney } from "~/app/list/formatMoney";
+import { cn } from "~/lib/utils";
+import { type RouterOutputs } from "~/trpc/react";
+import { PurchaseQuickAddButton } from "./PurchaseQuickAddButton";
+import Link from "next/link";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "~/components/ui/hover-card";
+import { buttonVariants } from "~/components/ui/button";
+import { Search } from "lucide-react";
+
+type RecentPurchase =
+  RouterOutputs["purchases"]["recentByIngredientIds"]["ingredientPurchases"][number]["purchases"][number];
+
+type Props = {
+  purchases: RecentPurchase[];
+  currentRecipeId?: number | null;
+  ingredientId?: number;
+  listItemId?: number;
+  className?: string;
+  emptyLabel?: string;
+  compact?: boolean;
+  hideEmpty?: boolean;
+};
+
+function formatPurchaseDate(value: string | Date) {
+  return new Date(value).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function IngredientPurchaseHistory(props: Props) {
+  const {
+    purchases,
+    currentRecipeId,
+    ingredientId,
+    listItemId,
+    className,
+    emptyLabel = "No recent purchases",
+    compact = false,
+    hideEmpty = false,
+  } = props;
+
+  if (!purchases.length) {
+    if (hideEmpty) return null;
+    return <p className={cn("text-xs text-muted-foreground", className)}>{emptyLabel}</p>;
+  }
+
+  const sameRecipe = purchases.filter((purchase) => {
+    if (!currentRecipeId) return true;
+    return purchase.linkedRecipe?.id === currentRecipeId;
+  });
+
+  const differentRecipe = purchases.filter((purchase) => {
+    if (!currentRecipeId) return false;
+    return purchase.linkedRecipe?.id !== currentRecipeId;
+  });
+
+  const groups: Array<{ key: string; label: string; items: RecentPurchase[] }> = [
+    { key: "same", label: "Same recipe", items: sameRecipe },
+    { key: "other", label: "Different recipe", items: differentRecipe },
+  ].filter((group) => group.items.length > 0);
+
+  if (compact) {
+    return (
+      <div className={cn("flex flex-wrap items-center gap-1.5", className)}>
+        {groups.flatMap((group) =>
+          group.items.map((purchase) => {
+            const recipeIdForQuickAdd =
+              typeof purchase.linkedRecipe?.id === "number"
+                ? purchase.linkedRecipe.id
+                : currentRecipeId ?? undefined;
+
+            return (
+              <HoverCard key={purchase.id} openDelay={80} closeDelay={120}>
+                <HoverCardTrigger
+                  className="overflow-hidden rounded-md border border-border/60 bg-background/60 transition hover:border-border hover:shadow-sm"
+                  aria-label={`View purchase details for ${purchase.krogerName}`}
+                >
+                  <img
+                    src={purchase.imageUrl}
+                    alt={purchase.krogerName}
+                    className="h-8 w-8 object-cover"
+                  />
+                </HoverCardTrigger>
+                <HoverCardContent
+                  align="start"
+                  side="top"
+                  className="w-72 rounded-2xl border bg-card p-3 shadow-xl"
+                >
+                  <div className="flex items-start gap-3">
+                    <img
+                      src={purchase.imageUrl}
+                      alt={purchase.krogerName}
+                      className="h-14 w-14 rounded-lg object-cover"
+                    />
+                    <div className="min-w-0">
+                      <p className="line-clamp-2 text-sm font-semibold">
+                        {purchase.krogerName}
+                      </p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        {formatPurchaseDate(purchase.createdAt)}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap items-center gap-1.5 text-xs">
+                    <span className="rounded-full bg-accent/60 px-2 py-0.5">
+                      {formatMoney(purchase.price)}
+                    </span>
+                    <span className="rounded-full bg-background/80 px-2 py-0.5 text-muted-foreground">
+                      Qty {purchase.quantity}
+                    </span>
+                    {purchase.linkedRecipe ? (
+                      <span className="rounded-full bg-background/80 px-2 py-0.5 text-muted-foreground">
+                        {purchase.linkedRecipe.name}
+                      </span>
+                    ) : null}
+                  </div>
+
+                  <div className="mt-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <PurchaseQuickAddButton
+                        purchase={purchase}
+                        ingredientId={ingredientId ?? purchase.ingredientId ?? undefined}
+                        recipeId={recipeIdForQuickAdd}
+                        listItemId={listItemId}
+                      />
+                      <Link
+                        href={`https://www.kroger.com/search?query=${encodeURIComponent(
+                          purchase.krogerName,
+                        )}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className={cn(
+                          buttonVariants({ variant: "outline", size: "sm" }),
+                          "h-8 gap-1.5 text-xs",
+                        )}
+                      >
+                        <Search className="h-3.5 w-3.5 shrink-0" />
+                        Search Kroger
+                      </Link>
+                    </div>
+                  </div>
+                </HoverCardContent>
+              </HoverCard>
+            );
+          }),
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      {groups.map((group) => (
+        <div key={group.key} className="space-y-1.5">
+          {currentRecipeId ? (
+            <p className="text-[11px] uppercase text-muted-foreground">{group.label}</p>
+          ) : null}
+          <div className="space-y-1.5">
+            {group.items.map((purchase) => {
+              const recipeIdForQuickAdd =
+                typeof purchase.linkedRecipe?.id === "number"
+                  ? purchase.linkedRecipe.id
+                  : currentRecipeId ?? undefined;
+
+              return (
+                <div
+                  key={purchase.id}
+                  className="rounded-xl border bg-background/80 px-2.5 py-2"
+                >
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+                    <img
+                      src={purchase.imageUrl}
+                      alt={purchase.krogerName}
+                      className="h-9 w-9 rounded-md object-cover"
+                    />
+                    <div className="min-w-0">
+                      <p className="truncate font-medium">
+                        {purchase.krogerName}
+                      </p>
+                      <div className="mt-1 flex flex-wrap items-center gap-1">
+                        <span className="rounded-full bg-accent/60 px-2 py-0.5">
+                          {formatMoney(purchase.price)}
+                        </span>
+                        <span className="rounded-full bg-background px-2 py-0.5 text-muted-foreground">
+                          Qty {purchase.quantity}
+                        </span>
+                        <span className="text-muted-foreground">
+                          {formatPurchaseDate(purchase.createdAt)}
+                        </span>
+                        {purchase.linkedRecipe ? (
+                          <span className="rounded-full bg-accent/60 px-2 py-0.5 text-[11px]">
+                            {purchase.linkedRecipe.name}
+                          </span>
+                        ) : null}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="mt-2">
+                    <PurchaseQuickAddButton
+                      purchase={purchase}
+                      ingredientId={ingredientId ?? purchase.ingredientId ?? undefined}
+                      recipeId={recipeIdForQuickAdd}
+                      listItemId={listItemId}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ingredients/PurchaseQuickAddButton.tsx
+++ b/src/components/ingredients/PurchaseQuickAddButton.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { ShoppingCart } from "lucide-react";
+import { IconTextButton } from "~/components/ui/icon-text-button";
+import { api, type RouterOutputs } from "~/trpc/react";
+
+type RecentPurchase =
+  RouterOutputs["purchases"]["recentByIngredientIds"]["ingredientPurchases"][number]["purchases"][number];
+
+type Props = {
+  purchase: RecentPurchase;
+  ingredientId?: number;
+  recipeId?: number;
+  listItemId?: number;
+  compact?: boolean;
+};
+
+export function PurchaseQuickAddButton(props: Props) {
+  const { purchase, ingredientId, recipeId, listItemId, compact = false } = props;
+  const utils = api.useUtils();
+  const addToCart = api.kroger.addToCart.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.purchases.list.invalidate(),
+        utils.purchases.recentByIngredientIds.invalidate(),
+        utils.purchases.ingredientsCatalog.invalidate(),
+        utils.shoppingList.getShoppingList.invalidate(),
+      ]);
+    },
+  });
+
+  return (
+    <IconTextButton
+      size="sm"
+      variant="secondary"
+      icon={<ShoppingCart className="h-3.5 w-3.5 shrink-0" />}
+      label={addToCart.isPending ? "Adding..." : compact ? "Add" : "Add again"}
+      disabled={addToCart.isPending}
+      onClick={() =>
+        addToCart.mutate({
+          items: [{ upc: purchase.krogerSku, quantity: purchase.quantity }],
+          listItemId,
+          ingredientId,
+          recipeId,
+          purchaseDetails: {
+            sku: purchase.krogerSku,
+            productId: purchase.krogerProductId,
+            name: purchase.krogerName,
+            brand: purchase.krogerBrand ?? undefined,
+            categories: purchase.krogerCategories,
+            itemId: purchase.krogerItemId ?? undefined,
+            soldBy: purchase.krogerSoldBy ?? undefined,
+            priceRegular: purchase.krogerPriceRegular ?? undefined,
+            pricePromo: purchase.krogerPricePromo ?? undefined,
+            price: purchase.price,
+            quantity: purchase.quantity,
+            size: purchase.itemSize,
+            imageUrl: purchase.imageUrl,
+          },
+        })
+      }
+      className={compact ? "h-7 px-2 text-xs" : "h-7 px-2.5 text-xs"}
+    />
+  );
+}

--- a/src/components/recipes/InlineTagEditor.tsx
+++ b/src/components/recipes/InlineTagEditor.tsx
@@ -9,13 +9,21 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "~/components/ui/popover";
+import { cn } from "~/lib/utils";
 import { api } from "~/trpc/react";
 
 export function InlineTagEditor(props: {
   values: string[];
   onChange: (vals: string[]) => void;
+  controlsLayout?: "inline" | "stacked";
+  addButtonClassName?: string;
 }) {
-  const { values, onChange } = props;
+  const {
+    values,
+    onChange,
+    controlsLayout = "inline",
+    addButtonClassName,
+  } = props;
   const [input, setInput] = useState("");
   const inputRef = useRef<HTMLInputElement | null>(null);
   const { data } = api.tag.search.useQuery({ q: input, limit: 10 });
@@ -57,13 +65,19 @@ export function InlineTagEditor(props: {
           </span>
         ))}
       </div>
-      <div className="flex items-center gap-2">
+      <div
+        className={
+          controlsLayout === "stacked"
+            ? "flex flex-col items-start gap-2"
+            : "flex items-center gap-2"
+        }
+      >
         <Input
           ref={inputRef}
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder="Add a tag"
-          className="max-w-sm"
+          className={controlsLayout === "stacked" ? "w-full" : "max-w-sm"}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
               e.preventDefault();
@@ -73,7 +87,12 @@ export function InlineTagEditor(props: {
         />
         <Popover>
           <PopoverTrigger asChild>
-            <Button variant="outline" size="sm" aria-label="Add tag">
+            <Button
+              variant="outline"
+              size="sm"
+              aria-label="Add tag"
+              className={cn(addButtonClassName)}
+            >
               <ChevronDown className="h-4 w-4" />
               Add tag
             </Button>

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -17,24 +17,24 @@ function Calendar({
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
-      className={cn("p-3", className)}
+      className={cn("", className)}
       classNames={{
         months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
-        month: "space-y-4",
-        caption: "flex justify-center pt-1 relative items-center",
+        month: "flex flex-col items-center space-y-4",
+        caption: "relative flex w-full items-center justify-center pt-1",
         caption_label: "text-sm font-medium",
-        nav: "space-x-1 flex items-center",
+        nav: "absolute left-2 right-2 top-1 flex items-center justify-between",
         nav_button: cn(
-          buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+          buttonVariants({ variant: "ghost" }),
+          "h-8 w-8 rounded-full p-0 text-muted-foreground hover:text-foreground",
         ),
-        nav_button_previous: "absolute left-1",
-        nav_button_next: "absolute right-1",
-        table: "w-full border-collapse space-y-1",
+        nav_button_previous: "",
+        nav_button_next: "",
+        table: "w-auto border-collapse space-y-1",
         head_row: "flex",
         head_cell:
           "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
-        row: "flex w-full mt-2",
+        row: "mt-2 flex",
         cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
         day: cn(
           buttonVariants({ variant: "ghost" }),

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -1,19 +1,21 @@
-import * as React from "react"
+import * as React from "react";
 
-const MOBILE_BREAKPOINT = 768
+const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
+    undefined,
+  );
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    };
+    mql.addEventListener("change", onChange);
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
 
-  return !!isMobile
+  return !!isMobile;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }

--- a/src/server/api/routers/krogerRouter.ts
+++ b/src/server/api/routers/krogerRouter.ts
@@ -66,6 +66,8 @@ export const krogerRouter = createTRPCRouter({
           }),
         ),
         listItemId: z.number().optional(),
+        ingredientId: z.number().optional(),
+        recipeId: z.number().optional(),
         purchaseDetails: z
           .object({
             sku: z.string(),
@@ -94,8 +96,8 @@ export const krogerRouter = createTRPCRouter({
       if (input.purchaseDetails) {
         const userId = ctx.session.user.id;
 
-        let ingredientId: number | null = null;
-        let recipeId: number | null = null;
+        let ingredientId: number | null = input.ingredientId ?? null;
+        let recipeId: number | null = input.recipeId ?? null;
         if (input.listItemId) {
           const listItem = await db.shoppingList.findUnique({
             where: { id: input.listItemId },
@@ -103,6 +105,19 @@ export const krogerRouter = createTRPCRouter({
           });
           ingredientId = listItem?.ingredientId ?? null;
           recipeId = listItem?.recipeId ?? null;
+        }
+        if (ingredientId && !recipeId) {
+          const ingredient = await db.ingredient.findUnique({
+            where: { id: ingredientId },
+            select: {
+              group: {
+                select: {
+                  recipeId: true,
+                },
+              },
+            },
+          });
+          recipeId = ingredient?.group.recipeId ?? null;
         }
 
         const created = await db.krogerPurchase.create({

--- a/src/server/api/routers/krogerRouter.ts
+++ b/src/server/api/routers/krogerRouter.ts
@@ -95,18 +95,21 @@ export const krogerRouter = createTRPCRouter({
         const userId = ctx.session.user.id;
 
         let ingredientId: number | null = null;
+        let recipeId: number | null = null;
         if (input.listItemId) {
           const listItem = await db.shoppingList.findUnique({
             where: { id: input.listItemId },
-            select: { ingredientId: true },
+            select: { ingredientId: true, recipeId: true },
           });
           ingredientId = listItem?.ingredientId ?? null;
+          recipeId = listItem?.recipeId ?? null;
         }
 
         const created = await db.krogerPurchase.create({
           data: {
             userId,
             ingredientId: ingredientId ?? undefined,
+            recipeId: recipeId ?? undefined,
             krogerSku: input.purchaseDetails.sku,
             krogerProductId: input.purchaseDetails.productId,
             krogerName: input.purchaseDetails.name,

--- a/src/server/api/routers/purchasesRouter.ts
+++ b/src/server/api/routers/purchasesRouter.ts
@@ -1,7 +1,46 @@
 import { z } from "zod";
 import { faker } from "@faker-js/faker";
+import { type Prisma } from "@prisma/client";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { db } from "~/server/db";
+
+const purchaseInclude = {
+  Recipe: {
+    select: {
+      id: true,
+      name: true,
+    },
+  },
+  ingredient: {
+    include: {
+      group: {
+        select: {
+          Recipe: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  },
+} satisfies Prisma.KrogerPurchaseInclude;
+
+type PurchaseWithRelations = Prisma.KrogerPurchaseGetPayload<{
+  include: typeof purchaseInclude;
+}>;
+
+function toDisplayPurchase(purchase: PurchaseWithRelations) {
+  const linkedRecipe = purchase.ingredient?.group?.Recipe ?? purchase.Recipe;
+  return {
+    ...purchase,
+    ingredientName: purchase.ingredient?.ingredient ?? null,
+    linkedRecipe: linkedRecipe
+      ? { id: linkedRecipe.id, name: linkedRecipe.name }
+      : null,
+  };
+}
 
 export const purchasesRouter = createTRPCRouter({
   list: protectedProcedure.query(async ({ ctx }) => {
@@ -9,40 +48,188 @@ export const purchasesRouter = createTRPCRouter({
 
     const purchases = await db.krogerPurchase.findMany({
       where: { userId },
-      include: {
-        Recipe: {
-          select: {
-            id: true,
-            name: true,
+      include: purchaseInclude,
+      orderBy: { createdAt: "desc" },
+    });
+    return purchases.map(toDisplayPurchase);
+  }),
+
+  recentByIngredientIds: protectedProcedure
+    .input(
+      z.object({
+        ingredientIds: z.array(z.coerce.number().int().positive()).max(300),
+        limit: z.coerce.number().int().min(1).max(10).optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const ingredientIds = Array.from(new Set(input.ingredientIds));
+      const limit = input.limit ?? 3;
+
+      if (ingredientIds.length === 0) {
+        return { ingredientPurchases: [] as const };
+      }
+
+      const purchases = await db.krogerPurchase.findMany({
+        where: {
+          userId,
+          ingredientId: { in: ingredientIds },
+        },
+        include: purchaseInclude,
+        orderBy: { createdAt: "desc" },
+      });
+
+      const grouped = new Map<number, ReturnType<typeof toDisplayPurchase>[]>();
+      for (const purchase of purchases) {
+        if (!purchase.ingredientId) continue;
+        const group = grouped.get(purchase.ingredientId) ?? [];
+        if (group.length < limit) {
+          group.push(toDisplayPurchase(purchase));
+          grouped.set(purchase.ingredientId, group);
+        }
+      }
+
+      return {
+        ingredientPurchases: ingredientIds.map((ingredientId) => ({
+          ingredientId,
+          purchases: grouped.get(ingredientId) ?? [],
+        })),
+      };
+    }),
+
+  ingredientsCatalog: protectedProcedure.query(async ({ ctx }) => {
+    const userId = ctx.session.user.id;
+
+    const ingredients = await db.ingredient.findMany({
+      where: {
+        group: {
+          Recipe: {
+            userId,
           },
         },
-        ingredient: {
-          include: {
-            group: {
+      },
+      include: {
+        group: {
+          select: {
+            Recipe: {
               select: {
-                Recipe: {
-                  select: {
-                    id: true,
-                    name: true,
-                  },
-                },
+                id: true,
+                name: true,
               },
             },
           },
         },
       },
+      orderBy: [{ ingredient: "asc" }, { id: "asc" }],
+    });
+
+    if (ingredients.length === 0) {
+      return [];
+    }
+
+    const ingredientIds = ingredients.map((ingredient) => ingredient.id);
+    const purchases = await db.krogerPurchase.findMany({
+      where: {
+        userId,
+        ingredientId: { in: ingredientIds },
+      },
+      include: purchaseInclude,
       orderBy: { createdAt: "desc" },
     });
-    return purchases.map((purchase) => {
-      const linkedRecipe = purchase.ingredient?.group?.Recipe ?? purchase.Recipe;
+
+    const groupByName = new Map<
+      string,
+      {
+        key: string;
+        name: string;
+        ingredientIds: number[];
+        aisleVotes: Record<string, number>;
+        recipes: Map<number, { id: number; name: string }>;
+      }
+    >();
+
+    for (const ingredient of ingredients) {
+      const normalized = ingredient.ingredient.trim().toLowerCase();
+      const key = normalized || String(ingredient.id);
+      const existing = groupByName.get(key);
+      if (existing) {
+        existing.ingredientIds.push(ingredient.id);
+        existing.recipes.set(ingredient.group.Recipe.id, {
+          id: ingredient.group.Recipe.id,
+          name: ingredient.group.Recipe.name,
+        });
+        const aisle = ingredient.aisle?.trim();
+        if (aisle) {
+          existing.aisleVotes[aisle] = (existing.aisleVotes[aisle] ?? 0) + 1;
+        }
+      } else {
+        groupByName.set(key, {
+          key,
+          name: ingredient.ingredient.trim() || ingredient.ingredient,
+          ingredientIds: [ingredient.id],
+          aisleVotes: ingredient.aisle?.trim()
+            ? { [ingredient.aisle.trim()]: 1 }
+            : {},
+          recipes: new Map([
+            [
+              ingredient.group.Recipe.id,
+              {
+                id: ingredient.group.Recipe.id,
+                name: ingredient.group.Recipe.name,
+              },
+            ],
+          ]),
+        });
+      }
+    }
+
+    const ingredientKeyById = new Map<number, string>();
+    for (const group of groupByName.values()) {
+      for (const id of group.ingredientIds) {
+        ingredientKeyById.set(id, group.key);
+      }
+    }
+
+    const purchaseCountByKey = new Map<string, number>();
+    const purchasesByKey = new Map<string, ReturnType<typeof toDisplayPurchase>[]>();
+
+    for (const purchase of purchases) {
+      if (!purchase.ingredientId) continue;
+      const key = ingredientKeyById.get(purchase.ingredientId);
+      if (!key) continue;
+
+      purchaseCountByKey.set(key, (purchaseCountByKey.get(key) ?? 0) + 1);
+
+      const current = purchasesByKey.get(key) ?? [];
+      if (current.length < 3) {
+        current.push(toDisplayPurchase(purchase));
+        purchasesByKey.set(key, current);
+      }
+    }
+
+    const results = Array.from(groupByName.values()).map((group) => {
+      const sortedRecipes = Array.from(group.recipes.values()).sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+      );
+      const topAisle =
+        Object.entries(group.aisleVotes).sort((a, b) => b[1] - a[1])[0]?.[0] ??
+        null;
       return {
-        ...purchase,
-        ingredientName: purchase.ingredient?.ingredient ?? null,
-        linkedRecipe: linkedRecipe
-          ? { id: linkedRecipe.id, name: linkedRecipe.name }
-          : null,
+        id: group.key,
+        ingredient: group.name,
+        ingredientIds: group.ingredientIds,
+        aisle: topAisle,
+        recipes: sortedRecipes,
+        purchaseCount: purchaseCountByKey.get(group.key) ?? 0,
+        recentPurchases: purchasesByKey.get(group.key) ?? [],
       };
     });
+
+    return results.sort((a, b) =>
+      a.ingredient.localeCompare(b.ingredient, undefined, {
+        sensitivity: "base",
+      }),
+    );
   }),
 
   seedDevPurchases: protectedProcedure


### PR DESCRIPTION
Summary
- add popular dishes and recently made sections below the calendar, keeping their cards aligned
- surface the "add to plan" action for popular dishes and clean up the calendar popover layout so buttons/spacing feel balanced
- update related components, hooks, and APIs to support the new UI and server changes

Testing
- Not run (not requested)