### PR TITLE
Reposition edit controls for ingredients and steps

### DIFF
--- a/src/app/recipes/[id]/DiscardChangesDialog.tsx
+++ b/src/app/recipes/[id]/DiscardChangesDialog.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "~/components/ui/alert-dialog";
+
+export function DiscardChangesDialog(props: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirmDiscard: () => void;
+}) {
+  const { open, onOpenChange, onConfirmDiscard } = props;
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Discard your changes?</AlertDialogTitle>
+          <AlertDialogDescription>
+            You have unsaved edits to ingredients or steps. If you cancel, those
+            changes will be lost.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Keep editing</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirmDiscard}>
+            Discard changes
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/app/recipes/[id]/EditModeActionButtons.tsx
+++ b/src/app/recipes/[id]/EditModeActionButtons.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Check, X } from "lucide-react";
+import { Button } from "~/components/ui/button";
+
+export function EditModeActionButtons(props: {
+  onSave: () => void;
+  onCancel: () => void;
+  isSaving: boolean;
+  className?: string;
+}) {
+  const { onSave, onCancel, isSaving, className } = props;
+
+  return (
+    <div className={className}>
+      <Button onClick={onSave} className="rounded-md" isLoading={isSaving}>
+        <Check className="shrink-0" />
+        Save
+      </Button>
+      <Button onClick={onCancel} variant="outline" className="rounded-md">
+        <X className="shrink-0" />
+        Cancel
+      </Button>
+    </div>
+  );
+}

--- a/src/app/recipes/[id]/IngredientList.tsx
+++ b/src/app/recipes/[id]/IngredientList.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { Ban, Edit } from "lucide-react";
-import { useMemo, useState } from "react";
-import { Button } from "~/components/ui/button";
+import { useMemo } from "react";
 import { H3, H4 } from "~/components/ui/typography";
-import { IngredientListEditMode } from "./IngredientListEditMode";
 import { type Recipe } from "./recipe-types";
 import { IngredientPurchaseHistory } from "~/components/ingredients/IngredientPurchaseHistory";
 import { api, type RouterOutputs } from "~/trpc/react";
@@ -16,8 +13,8 @@ export interface IngredientListProps {
   recipe: Recipe;
 }
 export function IngredientList({ recipe }: IngredientListProps) {
-  const [isEditing, setIsEditing] = useState(false);
   const { data: ingredientsCatalog } = api.purchases.ingredientsCatalog.useQuery();
+
   const purchasesByIngredientName = useMemo(() => {
     const m = new Map<string, RecentPurchase[]>();
     for (const ingredient of ingredientsCatalog ?? []) {
@@ -65,32 +62,10 @@ export function IngredientList({ recipe }: IngredientListProps) {
     </ul>
   );
 
-  const cancelBtn = (
-    <Button onClick={() => setIsEditing(!isEditing)} variant="outline">
-      <Ban />
-      Cancel
-    </Button>
-  );
   return (
     <>
-      <div className="flex items-center gap-4">
-        <H3>ingredients</H3>
-        {!isEditing && (
-          <Button onClick={() => setIsEditing(!isEditing)}>
-            <Edit />
-            Edit
-          </Button>
-        )}
-      </div>
-      {isEditing ? (
-        <IngredientListEditMode
-          recipe={recipe}
-          cancelButton={cancelBtn}
-          onDoneEditing={() => setIsEditing(false)}
-        />
-      ) : (
-        mainComp
-      )}
+      <H3 className="text-xl font-medium text-muted-foreground">ingredients</H3>
+      {mainComp}
     </>
   );
 }

--- a/src/app/recipes/[id]/IngredientList.tsx
+++ b/src/app/recipes/[id]/IngredientList.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { Edit } from "lucide-react";
 import { useMemo } from "react";
+import { Button } from "~/components/ui/button";
+import { TooltipButton } from "~/components/ui/tooltip-button";
 import { H3, H4 } from "~/components/ui/typography";
 import { type Recipe } from "./recipe-types";
 import { IngredientPurchaseHistory } from "~/components/ingredients/IngredientPurchaseHistory";
@@ -11,8 +14,9 @@ type RecentPurchase =
 
 export interface IngredientListProps {
   recipe: Recipe;
+  onStartEditing: () => void;
 }
-export function IngredientList({ recipe }: IngredientListProps) {
+export function IngredientList({ recipe, onStartEditing }: IngredientListProps) {
   const { data: ingredientsCatalog } = api.purchases.ingredientsCatalog.useQuery();
 
   const purchasesByIngredientName = useMemo(() => {
@@ -64,7 +68,19 @@ export function IngredientList({ recipe }: IngredientListProps) {
 
   return (
     <>
-      <H3 className="text-xl font-medium text-muted-foreground">ingredients</H3>
+      <div className="flex items-center justify-between gap-2">
+        <H3 className="text-xl font-medium text-muted-foreground">ingredients</H3>
+        <TooltipButton content="Edit recipe content">
+          <Button
+            onClick={onStartEditing}
+            variant="ghost"
+            size="icon"
+            className="rounded-md text-primary/70 hover:bg-primary/10 hover:text-primary"
+          >
+            <Edit className="size-5 shrink-0" />
+          </Button>
+        </TooltipButton>
+      </div>
       {mainComp}
     </>
   );

--- a/src/app/recipes/[id]/IngredientListEditMode.tsx
+++ b/src/app/recipes/[id]/IngredientListEditMode.tsx
@@ -9,6 +9,7 @@ import { Toggle } from "~/components/ui/toggle";
 import { TooltipButton } from "~/components/ui/tooltip-button";
 import { cn } from "~/lib/utils";
 import { type Recipe } from "./recipe-types";
+import { dirtyInputClass } from "./edit-mode-utils";
 
 type IngredientGroups = Recipe["ingredientGroups"];
 type Ingredient = IngredientGroups[number]["ingredients"][number];
@@ -18,8 +19,11 @@ export function IngredientListEditMode(props: {
   originalIngredientGroups: IngredientGroups;
   onIngredientGroupsChange: (ingredientGroups: IngredientGroups) => void;
 }) {
-  const { ingredientGroups, originalIngredientGroups, onIngredientGroupsChange } =
-    props;
+  const {
+    ingredientGroups,
+    originalIngredientGroups,
+    onIngredientGroupsChange,
+  } = props;
   const hasAdvancedValues = ingredientGroups.some((group) =>
     group.ingredients.some((ingredient) => {
       if (ingredient.id < 0) {
@@ -70,7 +74,9 @@ export function IngredientListEditMode(props: {
     if (group.id <= 0) {
       return undefined;
     }
-    return originalIngredientGroups.find((original) => original.id === group.id);
+    return originalIngredientGroups.find(
+      (original) => original.id === group.id,
+    );
   }
 
   function getOriginalIngredient(
@@ -81,17 +87,14 @@ export function IngredientListEditMode(props: {
     if (!originalGroup || ingredient.id <= 0) {
       return undefined;
     }
-    return originalGroup.ingredients.find((original) => original.id === ingredient.id);
-  }
-
-  function dirtyClass(isDirty: boolean) {
-    return cn(
-      "transition-colors hover:bg-primary/10 focus-visible:bg-primary/10",
-      isDirty && "border border-primary/30 shadow-[0_1px_0_0_hsl(var(--primary)/0.2)]",
+    return originalGroup.ingredients.find(
+      (original) => original.id === ingredient.id,
     );
   }
 
-  function setIngredientGroups(recipeUpdater: (draft: IngredientGroups) => void) {
+  function setIngredientGroups(
+    recipeUpdater: (draft: IngredientGroups) => void,
+  ) {
     onIngredientGroupsChange(produce(ingredientGroups, recipeUpdater));
   }
 
@@ -151,7 +154,10 @@ export function IngredientListEditMode(props: {
     });
   }
 
-  function handleDeleteIngredient(ingredientGroupIdx: number, ingredientIdx: number) {
+  function handleDeleteIngredient(
+    ingredientGroupIdx: number,
+    ingredientIdx: number,
+  ) {
     setIngredientGroups((draft) => {
       const group = draft[ingredientGroupIdx];
 
@@ -276,7 +282,7 @@ export function IngredientListEditMode(props: {
                 id={`ingredient-group-title-${igGroup.id ?? gIdx}`}
                 className={cn(
                   "h-10 w-auto max-w-[calc(100%-2.5rem)] rounded-sm bg-background/80 text-xl font-semibold",
-                  dirtyClass(isTitleDirty),
+                  dirtyInputClass(isTitleDirty),
                 )}
                 style={{ width: `${titleWidthCh}ch` }}
                 value={igGroup.title}
@@ -296,150 +302,165 @@ export function IngredientListEditMode(props: {
               </TooltipButton>
             </div>
 
-          <div className="ml-8 space-y-2">
-          <table className="w-[calc(100%-1rem)] border-collapse">
-            <thead>
-              <tr className="border-b border-border/30 text-left text-sm font-semibold text-muted-foreground">
-                {shouldShowAdvanced ? <th className="w-[12%] py-2 pr-3">Amount</th> : null}
-                {shouldShowAdvanced ? <th className="w-[12%] py-2 pr-3">Unit</th> : null}
-                <th
-                  className={cn(
-                    "py-2 pr-3",
-                    shouldShowAdvanced ? "w-[60%]" : "w-[84%]",
-                  )}
-                >
-                  Ingredient
-                </th>
-                {shouldShowAdvanced ? <th className="w-[16%] py-2 pr-3">Modifier</th> : null}
-                <th className="w-[8%] py-2" />
-              </tr>
-            </thead>
-            <tbody>
-              {igGroup.ingredients.map((ingredient, iIdx) => {
-                const disableEdit = ingredient.id < 0;
-                const isNew = ingredient.id === 0;
-                const originalIngredient = getOriginalIngredient(igGroup, ingredient);
-                const isAmountDirty =
-                  originalIngredient?.amount !== undefined
-                    ? ingredient.amount !== originalIngredient.amount
-                    : ingredient.amount !== "";
-                const isUnitDirty =
-                  originalIngredient?.unit !== undefined
-                    ? ingredient.unit !== originalIngredient.unit
-                    : ingredient.unit !== "";
-                const isNameDirty =
-                  originalIngredient?.ingredient !== undefined
-                    ? ingredient.ingredient !== originalIngredient.ingredient
-                    : ingredient.ingredient !== "";
-                const isModifierDirty =
-                  originalIngredient?.modifier !== undefined
-                    ? ingredient.modifier !== originalIngredient.modifier
-                    : ingredient.modifier !== "";
-
-                return (
-                  <tr
-                    key={ingredient.id || `${gIdx}-${iIdx}`}
-                    className={cn({
-                      "bg-red-100/60": disableEdit,
-                      "bg-emerald-100/20": isNew,
-                    })}
-                  >
+            <div className="ml-8 space-y-2">
+              <table className="w-[calc(100%-1rem)] border-collapse">
+                <thead>
+                  <tr className="border-b border-border/30 text-left text-sm font-semibold text-muted-foreground">
                     {shouldShowAdvanced ? (
-                      <td className="py-2 pr-3 align-top">
-                        <Input
-                          value={ingredient.amount}
-                          className={cn(
-                            "h-9 rounded-sm bg-background/70",
-                            dirtyClass(isAmountDirty),
-                          )}
-                          onChange={(e) =>
-                            handleIngredientChange(
-                              gIdx,
-                              iIdx,
-                              "amount",
-                              e.target.value,
-                            )
-                          }
-                          disabled={disableEdit}
-                        />
-                      </td>
+                      <th className="w-[12%] py-2 pr-3">Amount</th>
                     ) : null}
                     {shouldShowAdvanced ? (
-                      <td className="py-2 pr-3 align-top">
-                        <Input
-                          value={ingredient.unit}
-                          className={cn(
-                            "h-9 rounded-sm bg-background/70",
-                            dirtyClass(isUnitDirty),
-                          )}
-                          onChange={(e) =>
-                            handleIngredientChange(gIdx, iIdx, "unit", e.target.value)
-                          }
-                          disabled={disableEdit}
-                        />
-                      </td>
+                      <th className="w-[12%] py-2 pr-3">Unit</th>
                     ) : null}
-                    <td className="py-2 pr-3 align-top">
-                      <Input
-                        ref={(node) => {
-                          ingredientInputRefs.current[
-                            `${gIdx}-${iIdx}-ingredient`
-                          ] = node;
-                        }}
-                        value={ingredient.ingredient}
-                        className={cn(
-                          "h-9 rounded-sm bg-background/70",
-                          dirtyClass(isNameDirty),
-                        )}
-                        onChange={(e) =>
-                          handleIngredientChange(
-                            gIdx,
-                            iIdx,
-                            "ingredient",
-                            e.target.value,
-                          )
-                        }
-                        disabled={disableEdit}
-                      />
-                    </td>
+                    <th
+                      className={cn(
+                        "py-2 pr-3",
+                        shouldShowAdvanced ? "w-[60%]" : "w-[84%]",
+                      )}
+                    >
+                      Ingredient
+                    </th>
                     {shouldShowAdvanced ? (
-                      <td className="py-2 pr-3 align-top">
-                        <Input
-                          value={ingredient.modifier}
-                          className={cn(
-                            "h-9 rounded-sm bg-background/70",
-                            dirtyClass(isModifierDirty),
-                          )}
-                          onChange={(e) =>
-                            handleIngredientChange(
-                              gIdx,
-                              iIdx,
-                              "modifier",
-                              e.target.value,
-                            )
-                          }
-                          disabled={disableEdit}
-                        />
-                      </td>
+                      <th className="w-[16%] py-2 pr-3">Modifier</th>
                     ) : null}
-                    <td className="py-2 align-top">
-                      <TooltipButton content="Delete ingredient">
-                        <Button
-                          onClick={() => handleDeleteIngredient(gIdx, iIdx)}
-                          variant="ghost"
-                          size="icon"
-                          className="h-8 w-8 rounded-sm text-destructive/70 hover:bg-destructive/10 hover:text-destructive"
-                        >
-                          <Trash2 className="size-4 shrink-0" />
-                        </Button>
-                      </TooltipButton>
-                    </td>
+                    <th className="w-[8%] py-2" />
                   </tr>
-                );
-              })}
-            </tbody>
-          </table>
-          </div>
+                </thead>
+                <tbody>
+                  {igGroup.ingredients.map((ingredient, iIdx) => {
+                    const disableEdit = ingredient.id < 0;
+                    const isNew = ingredient.id === 0;
+                    const originalIngredient = getOriginalIngredient(
+                      igGroup,
+                      ingredient,
+                    );
+                    const isAmountDirty =
+                      originalIngredient?.amount !== undefined
+                        ? ingredient.amount !== originalIngredient.amount
+                        : ingredient.amount !== "";
+                    const isUnitDirty =
+                      originalIngredient?.unit !== undefined
+                        ? ingredient.unit !== originalIngredient.unit
+                        : ingredient.unit !== "";
+                    const isNameDirty =
+                      originalIngredient?.ingredient !== undefined
+                        ? ingredient.ingredient !==
+                          originalIngredient.ingredient
+                        : ingredient.ingredient !== "";
+                    const isModifierDirty =
+                      originalIngredient?.modifier !== undefined
+                        ? ingredient.modifier !== originalIngredient.modifier
+                        : ingredient.modifier !== "";
+
+                    return (
+                      <tr
+                        key={ingredient.id || `${gIdx}-${iIdx}`}
+                        className={cn({
+                          "bg-red-100/60": disableEdit,
+                          "bg-emerald-100/20": isNew,
+                        })}
+                      >
+                        {shouldShowAdvanced ? (
+                          <td className="py-2 pr-3 align-top">
+                            <Input
+                              value={ingredient.amount}
+                              className={cn(
+                                "h-9 rounded-sm bg-background/70",
+                                dirtyInputClass(isAmountDirty),
+                              )}
+                              onChange={(e) =>
+                                handleIngredientChange(
+                                  gIdx,
+                                  iIdx,
+                                  "amount",
+                                  e.target.value,
+                                )
+                              }
+                              disabled={disableEdit}
+                            />
+                          </td>
+                        ) : null}
+                        {shouldShowAdvanced ? (
+                          <td className="py-2 pr-3 align-top">
+                            <Input
+                              value={ingredient.unit}
+                              className={cn(
+                                "h-9 rounded-sm bg-background/70",
+                                dirtyInputClass(isUnitDirty),
+                              )}
+                              onChange={(e) =>
+                                handleIngredientChange(
+                                  gIdx,
+                                  iIdx,
+                                  "unit",
+                                  e.target.value,
+                                )
+                              }
+                              disabled={disableEdit}
+                            />
+                          </td>
+                        ) : null}
+                        <td className="py-2 pr-3 align-top">
+                          <Input
+                            ref={(node) => {
+                              ingredientInputRefs.current[
+                                `${gIdx}-${iIdx}-ingredient`
+                              ] = node;
+                            }}
+                            value={ingredient.ingredient}
+                            className={cn(
+                              "h-9 rounded-sm bg-background/70",
+                              dirtyInputClass(isNameDirty),
+                            )}
+                            onChange={(e) =>
+                              handleIngredientChange(
+                                gIdx,
+                                iIdx,
+                                "ingredient",
+                                e.target.value,
+                              )
+                            }
+                            disabled={disableEdit}
+                          />
+                        </td>
+                        {shouldShowAdvanced ? (
+                          <td className="py-2 pr-3 align-top">
+                            <Input
+                              value={ingredient.modifier}
+                              className={cn(
+                                "h-9 rounded-sm bg-background/70",
+                                dirtyInputClass(isModifierDirty),
+                              )}
+                              onChange={(e) =>
+                                handleIngredientChange(
+                                  gIdx,
+                                  iIdx,
+                                  "modifier",
+                                  e.target.value,
+                                )
+                              }
+                              disabled={disableEdit}
+                            />
+                          </td>
+                        ) : null}
+                        <td className="py-2 align-top">
+                          <TooltipButton content="Delete ingredient">
+                            <Button
+                              onClick={() => handleDeleteIngredient(gIdx, iIdx)}
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 rounded-sm text-destructive/70 hover:bg-destructive/10 hover:text-destructive"
+                            >
+                              <Trash2 className="size-4 shrink-0" />
+                            </Button>
+                          </TooltipButton>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
 
             <Button
               onClick={() => handleAddIngredient(gIdx)}

--- a/src/app/recipes/[id]/IngredientListEditMode.tsx
+++ b/src/app/recipes/[id]/IngredientListEditMode.tsx
@@ -1,30 +1,99 @@
 "use client";
+
 import { produce } from "immer";
-import { useState } from "react";
-import { useRecipeActions } from "~/app/useRecipeActions";
+import { FolderPlus, Plus, Trash2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
+import { Toggle } from "~/components/ui/toggle";
+import { TooltipButton } from "~/components/ui/tooltip-button";
 import { cn } from "~/lib/utils";
-import { type IngredientListProps } from "./IngredientList";
-import { Plus, Save } from "lucide-react";
+import { type Recipe } from "./recipe-types";
 
-type AddlProps = {
-  cancelButton: React.ReactNode;
-  onDoneEditing: () => void;
-};
+type IngredientGroups = Recipe["ingredientGroups"];
+type Ingredient = IngredientGroups[number]["ingredients"][number];
 
-export function IngredientListEditMode({
-  recipe,
-  cancelButton,
-  onDoneEditing,
-}: IngredientListProps & AddlProps) {
-  const [ingredientGroups, setIngredientGroups] = useState(
-    recipe.ingredientGroups,
+export function IngredientListEditMode(props: {
+  ingredientGroups: IngredientGroups;
+  originalIngredientGroups: IngredientGroups;
+  onIngredientGroupsChange: (ingredientGroups: IngredientGroups) => void;
+}) {
+  const { ingredientGroups, originalIngredientGroups, onIngredientGroupsChange } =
+    props;
+  const hasAdvancedValues = ingredientGroups.some((group) =>
+    group.ingredients.some((ingredient) => {
+      if (ingredient.id < 0) {
+        return false;
+      }
+
+      return [ingredient.amount, ingredient.unit, ingredient.modifier].some(
+        (value) => value.trim().length > 0,
+      );
+    }),
+  );
+  const [showAdvanced, setShowAdvanced] = useState(hasAdvancedValues);
+  const [pendingFocus, setPendingFocus] = useState<{
+    groupIdx: number;
+    ingredientIdx: number;
+  } | null>(null);
+  const ingredientInputRefs = useRef<Record<string, HTMLInputElement | null>>(
+    {},
   );
 
-  const { updateIngredientGroups } = useRecipeActions();
+  useEffect(() => {
+    if (hasAdvancedValues) {
+      setShowAdvanced(true);
+    }
+  }, [hasAdvancedValues]);
 
-  type Ingredient = (typeof ingredientGroups)[0]["ingredients"][0];
+  const shouldShowAdvanced = hasAdvancedValues || showAdvanced;
+  const canToggleAdvanced = !hasAdvancedValues;
+
+  useEffect(() => {
+    if (!pendingFocus) {
+      return;
+    }
+
+    const key = `${pendingFocus.groupIdx}-${pendingFocus.ingredientIdx}-ingredient`;
+    const target = ingredientInputRefs.current[key];
+
+    if (target) {
+      requestAnimationFrame(() => {
+        target.focus();
+        target.select();
+      });
+      setPendingFocus(null);
+    }
+  }, [ingredientGroups, pendingFocus]);
+
+  function getOriginalGroup(group: IngredientGroups[number]) {
+    if (group.id <= 0) {
+      return undefined;
+    }
+    return originalIngredientGroups.find((original) => original.id === group.id);
+  }
+
+  function getOriginalIngredient(
+    group: IngredientGroups[number],
+    ingredient: Ingredient,
+  ) {
+    const originalGroup = getOriginalGroup(group);
+    if (!originalGroup || ingredient.id <= 0) {
+      return undefined;
+    }
+    return originalGroup.ingredients.find((original) => original.id === ingredient.id);
+  }
+
+  function dirtyClass(isDirty: boolean) {
+    return cn(
+      "transition-colors hover:bg-primary/10 focus-visible:bg-primary/10",
+      isDirty && "border border-primary/30 shadow-[0_1px_0_0_hsl(var(--primary)/0.2)]",
+    );
+  }
+
+  function setIngredientGroups(recipeUpdater: (draft: IngredientGroups) => void) {
+    onIngredientGroupsChange(produce(ingredientGroups, recipeUpdater));
+  }
 
   function handleIngredientChange<K extends keyof Ingredient>(
     ingredientGroupIdx: number,
@@ -32,229 +101,362 @@ export function IngredientListEditMode({
     key: K,
     value: Ingredient[K],
   ) {
-    setIngredientGroups(
-      produce((draft) => {
-        const group = draft[ingredientGroupIdx];
+    setIngredientGroups((draft) => {
+      const group = draft[ingredientGroupIdx];
 
-        if (!group) {
-          return;
-        }
+      if (!group) {
+        return;
+      }
 
-        const ingredient = group.ingredients[ingredientIdx];
+      const ingredient = group.ingredients[ingredientIdx];
 
-        if (!ingredient) {
-          return;
-        }
+      if (!ingredient) {
+        return;
+      }
 
-        ingredient[key] = value;
-      }),
-    );
+      ingredient[key] = value;
+    });
   }
 
   function handleAddIngredient(ingredientGroupIdx: number) {
-    setIngredientGroups(
-      produce((draft) => {
-        const newIngredient: Ingredient = {
-          amount: "1",
-          unit: "",
-          ingredient: "New Ingredient",
-          modifier: "",
-          aisle: "",
-          comments: "",
-          groupId: -1,
-          id: 0,
-          isGoodName: false,
-          plu: "",
-          rawInput: "",
-        };
+    const nextIngredientIdx =
+      ingredientGroups[ingredientGroupIdx]?.ingredients.length ?? 0;
 
-        const group = draft[ingredientGroupIdx];
+    setIngredientGroups((draft) => {
+      const newIngredient: Ingredient = {
+        amount: "",
+        unit: "",
+        ingredient: "",
+        modifier: "",
+        aisle: "",
+        comments: "",
+        groupId: -1,
+        id: 0,
+        isGoodName: false,
+        plu: "",
+        rawInput: "",
+      };
 
-        if (!group) {
-          return;
-        }
+      const group = draft[ingredientGroupIdx];
 
-        group.ingredients.push(newIngredient);
-      }),
-    );
+      if (!group) {
+        return;
+      }
+
+      group.ingredients.push(newIngredient);
+    });
+    setPendingFocus({
+      groupIdx: ingredientGroupIdx,
+      ingredientIdx: nextIngredientIdx,
+    });
   }
 
-  function handleDeleteIngredient(
-    ingredientGroupIdx: number,
-    ingredientIdx: number,
-  ) {
-    setIngredientGroups(
-      produce((draft) => {
-        const group = draft[ingredientGroupIdx];
+  function handleDeleteIngredient(ingredientGroupIdx: number, ingredientIdx: number) {
+    setIngredientGroups((draft) => {
+      const group = draft[ingredientGroupIdx];
 
-        if (!group) {
-          return;
-        }
+      if (!group) {
+        return;
+      }
 
-        // mark the ingredient as negative so we can delete it on save
-        const ingredient = group.ingredients[ingredientIdx];
+      const ingredient = group.ingredients[ingredientIdx];
 
-        if (!ingredient) {
-          return;
-        }
+      if (!ingredient) {
+        return;
+      }
 
-        ingredient.id = -ingredient.id;
-      }),
-    );
+      if (ingredient.id === 0) {
+        group.ingredients.splice(ingredientIdx, 1);
+        return;
+      }
+
+      ingredient.id = -ingredient.id;
+    });
   }
 
   function handleTitleChange(ingredientGroupIdx: number, title: string) {
-    setIngredientGroups(
-      produce((draft) => {
-        const group = draft[ingredientGroupIdx];
+    setIngredientGroups((draft) => {
+      const group = draft[ingredientGroupIdx];
 
-        if (!group) {
-          return;
-        }
+      if (!group) {
+        return;
+      }
 
-        group.title = title;
-      }),
-    );
-  }
-
-  async function handleSave() {
-    const shouldSave = confirm("Are you sure you want to save these changes?");
-
-    if (!shouldSave) {
-      return;
-    }
-
-    console.log("saving", ingredientGroups);
-
-    await updateIngredientGroups.mutateAsync({
-      recipeId: recipe.id,
-      ingredientGroups,
+      group.title = title;
     });
-
-    // mark done editing
-    onDoneEditing();
   }
 
-  if (!recipe) {
-    return null;
+  function handleAddGroup() {
+    setIngredientGroups((draft) => {
+      const recipeId = draft[0]?.recipeId ?? -1;
+      draft.push({
+        id: 0,
+        title: "New group",
+        order: draft.length,
+        recipeId,
+        ingredients: [
+          {
+            amount: "",
+            unit: "",
+            ingredient: "",
+            modifier: "",
+            aisle: "",
+            comments: "",
+            groupId: -1,
+            id: 0,
+            isGoodName: false,
+            plu: "",
+            rawInput: "",
+          },
+        ],
+      });
+    });
+  }
+
+  function handleDeleteGroup(groupIdx: number) {
+    setIngredientGroups((draft) => {
+      const activeGroupsCount = draft.filter((group) => group.id >= 0).length;
+      if (activeGroupsCount <= 1) {
+        return;
+      }
+
+      const group = draft[groupIdx];
+      if (!group) {
+        return;
+      }
+
+      if (group.id === 0) {
+        draft.splice(groupIdx, 1);
+        return;
+      }
+
+      group.id = -group.id;
+    });
   }
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-4">
-        <Button onClick={handleSave}>
-          <Save />
-          Save
-        </Button>
-        {cancelButton}
+    <div className="w-full space-y-4">
+      <div className="flex items-center justify-end">
+        {canToggleAdvanced ? (
+          <Toggle
+            pressed={showAdvanced}
+            onPressedChange={setShowAdvanced}
+            variant="outline"
+            size="sm"
+            className="rounded-md"
+            aria-label="Show advanced ingredient fields"
+          >
+            Show advanced
+          </Toggle>
+        ) : null}
       </div>
 
-      {ingredientGroups.map((igGroup, gIdx) => (
-        <div key={gIdx}>
-          <Input
-            className="text-2xl"
-            value={igGroup.title}
-            onChange={(e) => handleTitleChange(gIdx, e.target.value)}
-            placeholder="Group Title"
-          />
+      {ingredientGroups.map((igGroup, gIdx) => {
+        const isDeleted = igGroup.id < 0;
+        const activeGroupsCount = ingredientGroups.filter(
+          (group) => group.id >= 0,
+        ).length;
+        const originalGroup = getOriginalGroup(igGroup);
+        const isTitleDirty =
+          originalGroup?.title !== undefined
+            ? igGroup.title !== originalGroup.title
+            : igGroup.title !== "New group";
+        const titleWidthCh = Math.max(8, igGroup.title.trim().length + 1);
 
-          <table>
+        return (
+          <div
+            key={igGroup.id ?? gIdx}
+            className={cn(
+              "space-y-1.5 rounded-md bg-card/40",
+              isDeleted && "bg-red-100/50",
+            )}
+          >
+            <div className="flex items-center gap-2">
+              <Input
+                id={`ingredient-group-title-${igGroup.id ?? gIdx}`}
+                className={cn(
+                  "h-10 w-auto max-w-[calc(100%-2.5rem)] rounded-sm bg-background/80 text-xl font-semibold",
+                  dirtyClass(isTitleDirty),
+                )}
+                style={{ width: `${titleWidthCh}ch` }}
+                value={igGroup.title}
+                onChange={(e) => handleTitleChange(gIdx, e.target.value)}
+                placeholder="Group title"
+              />
+              <TooltipButton content="Delete ingredient group">
+                <Button
+                  onClick={() => handleDeleteGroup(gIdx)}
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 rounded-sm text-destructive/70 hover:bg-destructive/10 hover:text-destructive disabled:opacity-30"
+                  disabled={activeGroupsCount <= 1 || isDeleted}
+                >
+                  <Trash2 className="size-4 shrink-0" />
+                </Button>
+              </TooltipButton>
+            </div>
+
+          <div className="ml-8 space-y-2">
+          <table className="w-[calc(100%-1rem)] border-collapse">
             <thead>
-              <tr>
-                <th>Amount</th>
-                <th>Unit</th>
-                <th>Ingredient</th>
-                <th>Modifier</th>
-                <th>Actions</th>
+              <tr className="border-b border-border/30 text-left text-sm font-semibold text-muted-foreground">
+                {shouldShowAdvanced ? <th className="w-[12%] py-2 pr-3">Amount</th> : null}
+                {shouldShowAdvanced ? <th className="w-[12%] py-2 pr-3">Unit</th> : null}
+                <th
+                  className={cn(
+                    "py-2 pr-3",
+                    shouldShowAdvanced ? "w-[60%]" : "w-[84%]",
+                  )}
+                >
+                  Ingredient
+                </th>
+                {shouldShowAdvanced ? <th className="w-[16%] py-2 pr-3">Modifier</th> : null}
+                <th className="w-[8%] py-2" />
               </tr>
             </thead>
-            {igGroup.ingredients.map((i, iIdx) => {
-              const disableEdit = i.id < 0;
-              const isNew = i.id === 0;
+            <tbody>
+              {igGroup.ingredients.map((ingredient, iIdx) => {
+                const disableEdit = ingredient.id < 0;
+                const isNew = ingredient.id === 0;
+                const originalIngredient = getOriginalIngredient(igGroup, ingredient);
+                const isAmountDirty =
+                  originalIngredient?.amount !== undefined
+                    ? ingredient.amount !== originalIngredient.amount
+                    : ingredient.amount !== "";
+                const isUnitDirty =
+                  originalIngredient?.unit !== undefined
+                    ? ingredient.unit !== originalIngredient.unit
+                    : ingredient.unit !== "";
+                const isNameDirty =
+                  originalIngredient?.ingredient !== undefined
+                    ? ingredient.ingredient !== originalIngredient.ingredient
+                    : ingredient.ingredient !== "";
+                const isModifierDirty =
+                  originalIngredient?.modifier !== undefined
+                    ? ingredient.modifier !== originalIngredient.modifier
+                    : ingredient.modifier !== "";
 
-              return (
-                <tr
-                  key={iIdx}
-                  className={cn({
-                    "bg-red-200": disableEdit,
-                    "bg-green-200": isNew,
-                  })}
-                >
-                  <td>
-                    <Input
-                      value={i.amount}
-                      onChange={(e) =>
-                        handleIngredientChange(
-                          gIdx,
-                          iIdx,
-                          "amount",
-                          e.target.value,
-                        )
-                      }
-                      disabled={disableEdit}
-                    />
-                  </td>
-                  <td>
-                    <Input
-                      value={i.unit}
-                      onChange={(e) =>
-                        handleIngredientChange(
-                          gIdx,
-                          iIdx,
-                          "unit",
-                          e.target.value,
-                        )
-                      }
-                      disabled={disableEdit}
-                    />
-                  </td>
-                  <td>
-                    <Input
-                      value={i.ingredient}
-                      onChange={(e) =>
-                        handleIngredientChange(
-                          gIdx,
-                          iIdx,
-                          "ingredient",
-                          e.target.value,
-                        )
-                      }
-                      disabled={disableEdit}
-                    />
-                  </td>
-                  <td>
-                    <Input
-                      value={i.modifier}
-                      onChange={(e) =>
-                        handleIngredientChange(
-                          gIdx,
-                          iIdx,
-                          "modifier",
-                          e.target.value,
-                        )
-                      }
-                      disabled={disableEdit}
-                    />
-                  </td>
-                  <td>
-                    <Button
-                      onClick={() => handleDeleteIngredient(gIdx, iIdx)}
-                      variant="destructive-outline"
-                    >
-                      Delete
-                    </Button>
-                  </td>
-                </tr>
-              );
-            })}
+                return (
+                  <tr
+                    key={ingredient.id || `${gIdx}-${iIdx}`}
+                    className={cn({
+                      "bg-red-100/60": disableEdit,
+                      "bg-emerald-100/20": isNew,
+                    })}
+                  >
+                    {shouldShowAdvanced ? (
+                      <td className="py-2 pr-3 align-top">
+                        <Input
+                          value={ingredient.amount}
+                          className={cn(
+                            "h-9 rounded-sm bg-background/70",
+                            dirtyClass(isAmountDirty),
+                          )}
+                          onChange={(e) =>
+                            handleIngredientChange(
+                              gIdx,
+                              iIdx,
+                              "amount",
+                              e.target.value,
+                            )
+                          }
+                          disabled={disableEdit}
+                        />
+                      </td>
+                    ) : null}
+                    {shouldShowAdvanced ? (
+                      <td className="py-2 pr-3 align-top">
+                        <Input
+                          value={ingredient.unit}
+                          className={cn(
+                            "h-9 rounded-sm bg-background/70",
+                            dirtyClass(isUnitDirty),
+                          )}
+                          onChange={(e) =>
+                            handleIngredientChange(gIdx, iIdx, "unit", e.target.value)
+                          }
+                          disabled={disableEdit}
+                        />
+                      </td>
+                    ) : null}
+                    <td className="py-2 pr-3 align-top">
+                      <Input
+                        ref={(node) => {
+                          ingredientInputRefs.current[
+                            `${gIdx}-${iIdx}-ingredient`
+                          ] = node;
+                        }}
+                        value={ingredient.ingredient}
+                        className={cn(
+                          "h-9 rounded-sm bg-background/70",
+                          dirtyClass(isNameDirty),
+                        )}
+                        onChange={(e) =>
+                          handleIngredientChange(
+                            gIdx,
+                            iIdx,
+                            "ingredient",
+                            e.target.value,
+                          )
+                        }
+                        disabled={disableEdit}
+                      />
+                    </td>
+                    {shouldShowAdvanced ? (
+                      <td className="py-2 pr-3 align-top">
+                        <Input
+                          value={ingredient.modifier}
+                          className={cn(
+                            "h-9 rounded-sm bg-background/70",
+                            dirtyClass(isModifierDirty),
+                          )}
+                          onChange={(e) =>
+                            handleIngredientChange(
+                              gIdx,
+                              iIdx,
+                              "modifier",
+                              e.target.value,
+                            )
+                          }
+                          disabled={disableEdit}
+                        />
+                      </td>
+                    ) : null}
+                    <td className="py-2 align-top">
+                      <TooltipButton content="Delete ingredient">
+                        <Button
+                          onClick={() => handleDeleteIngredient(gIdx, iIdx)}
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8 rounded-sm text-destructive/70 hover:bg-destructive/10 hover:text-destructive"
+                        >
+                          <Trash2 className="size-4 shrink-0" />
+                        </Button>
+                      </TooltipButton>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
           </table>
+          </div>
 
-          <Button onClick={() => handleAddIngredient(gIdx)} variant="secondary">
-            <Plus />
-            Add Ingredient to Group
-          </Button>
-        </div>
-      ))}
+            <Button
+              onClick={() => handleAddIngredient(gIdx)}
+              variant="secondary"
+              className="ml-8 rounded-md"
+            >
+              <Plus className="shrink-0" />
+              Add Ingredient to Group
+            </Button>
+          </div>
+        );
+      })}
+
+      <Button onClick={handleAddGroup} className="rounded-md">
+        <FolderPlus className="shrink-0" />
+        Add Ingredient Group
+      </Button>
     </div>
   );
 }

--- a/src/app/recipes/[id]/RecipeClient.tsx
+++ b/src/app/recipes/[id]/RecipeClient.tsx
@@ -1,5 +1,19 @@
 "use client";
 
+import { Check, Edit, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useRecipeActions } from "~/app/useRecipeActions";
+import { Button } from "~/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "~/components/ui/alert-dialog";
 import { api } from "~/trpc/react";
 import { IngredientList } from "./IngredientList";
 import { StepList } from "./StepList";
@@ -7,30 +21,228 @@ import { CookingModeOverlay } from "./CookingModeOverlay";
 import { RecipeHeader } from "./RecipeHeader";
 import { RecipeImagesSection } from "./RecipeImagesSection";
 import { CardGrid } from "~/components/layout/CardGrid";
+import { IngredientListEditMode } from "./IngredientListEditMode";
+import { StepListEditMode } from "./StepListEditMode";
+import { type Recipe } from "./recipe-types";
 
 export function RecipeClient(props: { id: number }) {
   const { id } = props;
+  const [isEditing, setIsEditing] = useState(false);
+  const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false);
+  const [ingredientGroupsDraft, setIngredientGroupsDraft] = useState<
+    Recipe["ingredientGroups"]
+  >([]);
+  const [stepGroupsDraft, setStepGroupsDraft] = useState<Recipe["stepGroups"]>(
+    [],
+  );
+  const { updateIngredientGroups, updateStepGroups } = useRecipeActions();
+  const utils = api.useUtils();
 
   const { data: recipe } = api.recipe.getRecipe.useQuery({
     id,
   });
 
+  const hasIngredientChanges = recipe
+    ? JSON.stringify(ingredientGroupsDraft) !==
+      JSON.stringify(recipe.ingredientGroups)
+    : false;
+  const hasStepChanges = recipe
+    ? JSON.stringify(stepGroupsDraft) !== JSON.stringify(recipe.stepGroups)
+    : false;
+  const hasAnyChanges = hasIngredientChanges || hasStepChanges;
+
+  useEffect(() => {
+    if (!isEditing || !recipe) {
+      return;
+    }
+
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+
+        if (isCancelConfirmOpen) {
+          return;
+        }
+
+        if (hasAnyChanges) {
+          setIsCancelConfirmOpen(true);
+          return;
+        }
+
+        setIsEditing(false);
+      }
+    }
+
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [hasAnyChanges, isCancelConfirmOpen, isEditing, recipe]);
+
   if (!recipe) {
     return <div>Recipe not found</div>;
+  }
+
+  function beginEditing() {
+    setIngredientGroupsDraft(recipe.ingredientGroups);
+    setStepGroupsDraft(recipe.stepGroups);
+    setIsEditing(true);
+  }
+
+  function handleCancelRequest() {
+    if (!hasAnyChanges) {
+      setIsEditing(false);
+      return;
+    }
+
+    setIsCancelConfirmOpen(true);
+  }
+
+  async function handleSaveAll() {
+    if (!hasAnyChanges) {
+      setIsEditing(false);
+      return;
+    }
+
+    await Promise.all([
+      updateIngredientGroups.mutateAsync({
+        recipeId: recipe.id,
+        ingredientGroups: ingredientGroupsDraft,
+      }),
+      updateStepGroups.mutateAsync({
+        recipeId: recipe.id,
+        stepGroups: stepGroupsDraft,
+      }),
+    ]);
+    await utils.recipe.getRecipe.invalidate({ id: recipe.id });
+
+    setIsEditing(false);
   }
 
   return (
     <div className="relative w-full space-y-6">
       <RecipeHeader recipe={recipe} />
 
-      <CardGrid className="lg:grid-cols-[2fr_3fr]">
-        <section className="rounded-2xl border bg-card/70 p-6 shadow-sm">
-          <IngredientList recipe={recipe} />
+      {isEditing ? (
+        <section className="space-y-4 rounded-xl border bg-card/70 p-6 shadow-sm">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                Editing mode
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Editing ingredients and instructions together. Press Save to
+                apply all changes.
+              </p>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Button
+                onClick={handleSaveAll}
+                className="rounded-md"
+                isLoading={updateIngredientGroups.isPending || updateStepGroups.isPending}
+              >
+                <Check className="shrink-0" />
+                Save
+              </Button>
+              <Button
+                onClick={handleCancelRequest}
+                variant="outline"
+                className="rounded-md"
+              >
+                <X className="shrink-0" />
+                Cancel
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div className="space-y-3">
+              <h3 className="text-3xl font-bold tracking-tight">ingredients</h3>
+              <p className="text-sm text-muted-foreground">
+                Ingredients are organized in editable groups.
+              </p>
+              <IngredientListEditMode
+                ingredientGroups={ingredientGroupsDraft}
+                originalIngredientGroups={recipe.ingredientGroups}
+                onIngredientGroupsChange={setIngredientGroupsDraft}
+              />
+            </div>
+
+            <div className="space-y-3">
+              <h3 className="text-3xl font-bold tracking-tight">instructions</h3>
+              <p className="text-sm text-muted-foreground">
+                Steps are organized in editable groups.
+              </p>
+              <StepListEditMode
+                stepGroups={stepGroupsDraft}
+                originalStepGroups={recipe.stepGroups}
+                onStepGroupsChange={setStepGroupsDraft}
+              />
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-2">
+            <Button
+              onClick={handleSaveAll}
+              className="rounded-md"
+              isLoading={updateIngredientGroups.isPending || updateStepGroups.isPending}
+            >
+              <Check className="shrink-0" />
+              Save
+            </Button>
+            <Button
+              onClick={handleCancelRequest}
+              variant="outline"
+              className="rounded-md"
+            >
+              <X className="shrink-0" />
+              Cancel
+            </Button>
+          </div>
+
+          <AlertDialog
+            open={isCancelConfirmOpen}
+            onOpenChange={setIsCancelConfirmOpen}
+          >
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Discard your changes?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  You have unsaved edits to ingredients or steps. If you
+                  cancel, those changes will be lost.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Keep editing</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={() => {
+                    setIsCancelConfirmOpen(false);
+                    setIsEditing(false);
+                  }}
+                >
+                  Discard changes
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </section>
-        <section className="rounded-2xl border bg-card/70 p-6 shadow-sm">
-          <StepList recipe={recipe} />
-        </section>
-      </CardGrid>
+      ) : (
+        <>
+          <div className="flex justify-end">
+            <Button onClick={beginEditing} className="rounded-md">
+              <Edit className="shrink-0" />
+              Edit Recipe Content
+            </Button>
+          </div>
+          <CardGrid className="lg:grid-cols-[2fr_3fr]">
+          <section className="rounded-xl border bg-card/70 p-6 shadow-sm">
+            <IngredientList recipe={recipe} />
+          </section>
+          <section className="rounded-xl border bg-card/70 p-6 shadow-sm">
+            <StepList recipe={recipe} />
+          </section>
+          </CardGrid>
+        </>
+      )}
 
       <CookingModeOverlay recipe={recipe} />
 

--- a/src/app/recipes/[id]/RecipeClient.tsx
+++ b/src/app/recipes/[id]/RecipeClient.tsx
@@ -1,19 +1,9 @@
 "use client";
 
-import { Check, Edit, X } from "lucide-react";
+import { Edit } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useRecipeActions } from "~/app/useRecipeActions";
 import { Button } from "~/components/ui/button";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "~/components/ui/alert-dialog";
 import { api } from "~/trpc/react";
 import { IngredientList } from "./IngredientList";
 import { StepList } from "./StepList";
@@ -24,6 +14,8 @@ import { CardGrid } from "~/components/layout/CardGrid";
 import { IngredientListEditMode } from "./IngredientListEditMode";
 import { StepListEditMode } from "./StepListEditMode";
 import { type Recipe } from "./recipe-types";
+import { EditModeActionButtons } from "./EditModeActionButtons";
+import { DiscardChangesDialog } from "./DiscardChangesDialog";
 
 export function RecipeClient(props: { id: number }) {
   const { id } = props;
@@ -134,24 +126,14 @@ export function RecipeClient(props: { id: number }) {
               </p>
             </div>
 
-            <div className="flex items-center gap-3">
-              <Button
-                onClick={handleSaveAll}
-                className="rounded-md"
-                isLoading={updateIngredientGroups.isPending || updateStepGroups.isPending}
-              >
-                <Check className="shrink-0" />
-                Save
-              </Button>
-              <Button
-                onClick={handleCancelRequest}
-                variant="outline"
-                className="rounded-md"
-              >
-                <X className="shrink-0" />
-                Cancel
-              </Button>
-            </div>
+            <EditModeActionButtons
+              onSave={handleSaveAll}
+              onCancel={handleCancelRequest}
+              isSaving={
+                updateIngredientGroups.isPending || updateStepGroups.isPending
+              }
+              className="flex items-center gap-3"
+            />
           </div>
 
           <div className="space-y-6">
@@ -168,7 +150,9 @@ export function RecipeClient(props: { id: number }) {
             </div>
 
             <div className="space-y-3">
-              <h3 className="text-3xl font-bold tracking-tight">instructions</h3>
+              <h3 className="text-3xl font-bold tracking-tight">
+                instructions
+              </h3>
               <p className="text-sm text-muted-foreground">
                 Steps are organized in editable groups.
               </p>
@@ -180,50 +164,23 @@ export function RecipeClient(props: { id: number }) {
             </div>
           </div>
 
-          <div className="flex justify-end gap-3 pt-2">
-            <Button
-              onClick={handleSaveAll}
-              className="rounded-md"
-              isLoading={updateIngredientGroups.isPending || updateStepGroups.isPending}
-            >
-              <Check className="shrink-0" />
-              Save
-            </Button>
-            <Button
-              onClick={handleCancelRequest}
-              variant="outline"
-              className="rounded-md"
-            >
-              <X className="shrink-0" />
-              Cancel
-            </Button>
-          </div>
+          <EditModeActionButtons
+            onSave={handleSaveAll}
+            onCancel={handleCancelRequest}
+            isSaving={
+              updateIngredientGroups.isPending || updateStepGroups.isPending
+            }
+            className="flex justify-end gap-3 pt-2"
+          />
 
-          <AlertDialog
+          <DiscardChangesDialog
             open={isCancelConfirmOpen}
             onOpenChange={setIsCancelConfirmOpen}
-          >
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Discard your changes?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  You have unsaved edits to ingredients or steps. If you
-                  cancel, those changes will be lost.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Keep editing</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={() => {
-                    setIsCancelConfirmOpen(false);
-                    setIsEditing(false);
-                  }}
-                >
-                  Discard changes
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+            onConfirmDiscard={() => {
+              setIsCancelConfirmOpen(false);
+              setIsEditing(false);
+            }}
+          />
         </section>
       ) : (
         <>
@@ -234,12 +191,12 @@ export function RecipeClient(props: { id: number }) {
             </Button>
           </div>
           <CardGrid className="lg:grid-cols-[2fr_3fr]">
-          <section className="rounded-xl border bg-card/70 p-6 shadow-sm">
-            <IngredientList recipe={recipe} />
-          </section>
-          <section className="rounded-xl border bg-card/70 p-6 shadow-sm">
-            <StepList recipe={recipe} />
-          </section>
+            <section className="rounded-xl border bg-card/70 p-6 shadow-sm">
+              <IngredientList recipe={recipe} />
+            </section>
+            <section className="rounded-xl border bg-card/70 p-6 shadow-sm">
+              <StepList recipe={recipe} />
+            </section>
           </CardGrid>
         </>
       )}

--- a/src/app/recipes/[id]/StepList.tsx
+++ b/src/app/recipes/[id]/StepList.tsx
@@ -1,18 +1,12 @@
 "use client";
 
-import { Ban, Edit } from "lucide-react";
-import { useState } from "react";
-import { Button } from "~/components/ui/button";
 import { H3, H4 } from "~/components/ui/typography";
 import { type Recipe } from "./recipe-types";
-import { StepListEditMode } from "./StepListEditMode";
 
 export type StepListProps = {
   recipe: Recipe;
 };
 export function StepList({ recipe }: StepListProps) {
-  const [isEditing, setIsEditing] = useState(false);
-
   if (!recipe) {
     return null;
   }
@@ -44,34 +38,10 @@ export function StepList({ recipe }: StepListProps) {
     </div>
   );
 
-  const cancelBtn = (
-    <Button onClick={() => setIsEditing(!isEditing)} variant="outline">
-      <Ban />
-      Cancel
-    </Button>
-  );
-
   return (
     <>
-      <div className="flex gap-4">
-        <H3>instructions</H3>
-        {!isEditing && (
-          <Button onClick={() => setIsEditing(!isEditing)}>
-            <Edit />
-            Edit
-          </Button>
-        )}
-      </div>
-
-      {isEditing ? (
-        <StepListEditMode
-          recipe={recipe}
-          cancelButton={cancelBtn}
-          onDoneEditing={() => setIsEditing(false)}
-        />
-      ) : (
-        mainComp
-      )}
+      <H3 className="text-xl font-medium text-muted-foreground">instructions</H3>
+      {mainComp}
     </>
   );
 }

--- a/src/app/recipes/[id]/StepList.tsx
+++ b/src/app/recipes/[id]/StepList.tsx
@@ -1,12 +1,16 @@
 "use client";
 
+import { Edit } from "lucide-react";
+import { Button } from "~/components/ui/button";
+import { TooltipButton } from "~/components/ui/tooltip-button";
 import { H3, H4 } from "~/components/ui/typography";
 import { type Recipe } from "./recipe-types";
 
 export type StepListProps = {
   recipe: Recipe;
+  onStartEditing: () => void;
 };
-export function StepList({ recipe }: StepListProps) {
+export function StepList({ recipe, onStartEditing }: StepListProps) {
   if (!recipe) {
     return null;
   }
@@ -40,7 +44,19 @@ export function StepList({ recipe }: StepListProps) {
 
   return (
     <>
-      <H3 className="text-xl font-medium text-muted-foreground">instructions</H3>
+      <div className="flex items-center justify-between gap-2">
+        <H3 className="text-xl font-medium text-muted-foreground">instructions</H3>
+        <TooltipButton content="Edit recipe content">
+          <Button
+            onClick={onStartEditing}
+            variant="ghost"
+            size="icon"
+            className="rounded-md text-primary/70 hover:bg-primary/10 hover:text-primary"
+          >
+            <Edit className="size-5 shrink-0" />
+          </Button>
+        </TooltipButton>
+      </div>
       {mainComp}
     </>
   );

--- a/src/app/recipes/[id]/StepListEditMode.tsx
+++ b/src/app/recipes/[id]/StepListEditMode.tsx
@@ -2,6 +2,7 @@
 
 import { produce } from "immer";
 import { FolderPlus, Plus, Trash2 } from "lucide-react";
+import { Fragment } from "react";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
@@ -76,6 +77,19 @@ export function StepListEditMode(props: {
       group.steps.push("");
     });
     setPendingFocus({ groupIdx, stepIdx: nextStepIdx });
+  }
+
+  function handleInsertStep(groupIdx: number, stepIdx: number) {
+    const insertAt = stepIdx + 1;
+
+    setStepGroups((draft) => {
+      const group = draft[groupIdx];
+      if (!group) {
+        return;
+      }
+      group.steps.splice(insertAt, 0, "");
+    });
+    setPendingFocus({ groupIdx, stepIdx: insertAt });
   }
 
   function handleDeleteStep(groupIdx: number, stepIdx: number) {
@@ -182,41 +196,52 @@ export function StepListEditMode(props: {
                     : step.trim().length > 0;
 
                 return (
-                  <div
-                    key={`${group.id || groupIdx}-${stepIdx}`}
-                    className="grid grid-cols-[2.5rem_1fr_auto] items-start gap-2 rounded-sm bg-background/55 p-2"
-                  >
-                    <div className="flex h-9 items-center justify-center rounded-sm bg-muted/40 text-sm font-semibold text-muted-foreground">
-                      {stepIdx + 1}
+                  <Fragment key={`${group.id || groupIdx}-${stepIdx}`}>
+                    <div className="relative grid grid-cols-[2.5rem_1fr_auto] items-start gap-2 rounded-sm bg-background/55 p-2">
+                      <div className="flex h-9 items-center justify-center rounded-sm bg-muted/40 text-sm font-semibold text-muted-foreground">
+                        {stepIdx + 1}
+                      </div>
+                      <Textarea
+                        ref={(node) => {
+                          stepTextareaRefs.current[`${groupIdx}-${stepIdx}`] =
+                            node;
+                        }}
+                        value={step}
+                        onChange={(e) =>
+                          handleStepChange(groupIdx, stepIdx, e.target.value)
+                        }
+                        autoResize
+                        rows={1}
+                        className={cn(
+                          "h-10 min-h-0 rounded-sm bg-background/80 text-base",
+                          dirtyInputClass(isStepDirty),
+                        )}
+                        placeholder="Describe this step"
+                      />
+                      <TooltipButton content="Delete step">
+                        <Button
+                          onClick={() => handleDeleteStep(groupIdx, stepIdx)}
+                          variant="ghost"
+                          size="icon"
+                          className="h-9 w-9 rounded-sm text-destructive/70 hover:bg-destructive/10 hover:text-destructive"
+                        >
+                          <Trash2 className="size-4 shrink-0" />
+                        </Button>
+                      </TooltipButton>
+                      {stepIdx < group.steps.length - 1 ? (
+                        <TooltipButton content="Insert step below">
+                          <Button
+                            onClick={() => handleInsertStep(groupIdx, stepIdx)}
+                            variant="ghost"
+                            size="icon"
+                            className="absolute -left-2 top-full z-10 h-6 w-6 -translate-y-1/2 rounded-sm text-muted-foreground/60 hover:bg-primary/10 hover:text-primary/80"
+                          >
+                            <Plus className="size-3.5 shrink-0" />
+                          </Button>
+                        </TooltipButton>
+                      ) : null}
                     </div>
-                    <Textarea
-                      ref={(node) => {
-                        stepTextareaRefs.current[`${groupIdx}-${stepIdx}`] =
-                          node;
-                      }}
-                      value={step}
-                      onChange={(e) =>
-                        handleStepChange(groupIdx, stepIdx, e.target.value)
-                      }
-                      autoResize
-                      rows={1}
-                      className={cn(
-                        "h-10 min-h-0 rounded-sm bg-background/80 text-base",
-                        dirtyInputClass(isStepDirty),
-                      )}
-                      placeholder="Describe this step"
-                    />
-                    <TooltipButton content="Delete step">
-                      <Button
-                        onClick={() => handleDeleteStep(groupIdx, stepIdx)}
-                        variant="ghost"
-                        size="icon"
-                        className="h-9 w-9 rounded-sm text-destructive/70 hover:bg-destructive/10 hover:text-destructive"
-                      >
-                        <Trash2 className="size-4 shrink-0" />
-                      </Button>
-                    </TooltipButton>
-                  </div>
+                  </Fragment>
                 );
               })}
             </div>

--- a/src/app/recipes/[id]/StepListEditMode.tsx
+++ b/src/app/recipes/[id]/StepListEditMode.tsx
@@ -1,205 +1,245 @@
 "use client";
 
-import { type StepGroup } from "@prisma/client";
 import { produce } from "immer";
-import { ListPlus, ListX, Plus, Save, Trash } from "lucide-react";
-import { useState } from "react";
-import { useRecipeActions } from "~/app/useRecipeActions";
+import { FolderPlus, Plus, Trash2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Textarea } from "~/components/ui/textarea";
+import { TooltipButton } from "~/components/ui/tooltip-button";
 import { cn } from "~/lib/utils";
-import { type StepListProps } from "./StepList";
+import { type Recipe } from "./recipe-types";
 
-type AddlProps = {
-  cancelButton: React.ReactNode;
-  onDoneEditing: () => void;
-};
+type StepGroups = Recipe["stepGroups"];
 
-export function StepListEditMode({
-  recipe,
-  cancelButton,
-  onDoneEditing,
-}: StepListProps & AddlProps) {
-  const [stepGroups, setStepGroups] = useState(recipe.stepGroups);
+export function StepListEditMode(props: {
+  stepGroups: StepGroups;
+  originalStepGroups: StepGroups;
+  onStepGroupsChange: (stepGroups: StepGroups) => void;
+}) {
+  const { stepGroups, originalStepGroups, onStepGroupsChange } = props;
+  const [pendingFocus, setPendingFocus] = useState<{
+    groupIdx: number;
+    stepIdx: number;
+  } | null>(null);
+  const stepTextareaRefs = useRef<Record<string, HTMLTextAreaElement | null>>(
+    {},
+  );
 
-  const { updateStepGroups } = useRecipeActions();
+  function getOriginalGroup(group: StepGroups[number]) {
+    if (group.id <= 0) {
+      return undefined;
+    }
+    return originalStepGroups.find((original) => original.id === group.id);
+  }
 
-  function handleStepChange(groupIdx: number, stepIdx: number, value: string) {
-    setStepGroups(
-      produce((draft) => {
-        const group = draft[groupIdx];
-        if (!group) {
-          return;
-        }
-        group.steps[stepIdx] = value;
-      }),
+  function dirtyClass(isDirty: boolean) {
+    return cn(
+      "transition-colors hover:bg-primary/10 focus-visible:bg-primary/10",
+      isDirty && "border border-primary/30 shadow-[0_1px_0_0_hsl(var(--primary)/0.2)]",
     );
   }
 
-  function handleAddStep(groupIdx: number) {
-    setStepGroups(
-      produce((draft) => {
-        const group = draft[groupIdx];
-        if (!group) {
-          return;
-        }
-        group.steps.push("New step");
-      }),
-    );
+  function setStepGroups(recipeUpdater: (draft: StepGroups) => void) {
+    onStepGroupsChange(produce(stepGroups, recipeUpdater));
   }
 
-  function handleDeleteStep(groupIdx: number, stepIdx: number) {
-    setStepGroups(
-      produce((draft) => {
-        const group = draft[groupIdx];
-        if (!group) {
-          return;
-        }
-        group.steps.splice(stepIdx, 1);
-      }),
-    );
-  }
-
-  function handleTitleChange(groupIdx: number, value: string) {
-    setStepGroups(
-      produce((draft) => {
-        const group = draft[groupIdx];
-        if (!group) {
-          return;
-        }
-        group.title = value;
-      }),
-    );
-  }
-
-  async function handleSave() {
-    const shouldSave = confirm("Are you sure you want to save these changes?");
-
-    if (!shouldSave) {
+  useEffect(() => {
+    if (!pendingFocus) {
       return;
     }
 
-    await updateStepGroups.mutateAsync({
-      recipeId: recipe.id,
-      stepGroups,
-    });
+    const key = `${pendingFocus.groupIdx}-${pendingFocus.stepIdx}`;
+    const target = stepTextareaRefs.current[key];
 
-    onDoneEditing();
+    if (target) {
+      requestAnimationFrame(() => {
+        target.focus();
+        target.select();
+      });
+      setPendingFocus(null);
+    }
+  }, [stepGroups, pendingFocus]);
+
+  function handleStepChange(groupIdx: number, stepIdx: number, value: string) {
+    setStepGroups((draft) => {
+      const group = draft[groupIdx];
+      if (!group) {
+        return;
+      }
+      group.steps[stepIdx] = value;
+    });
+  }
+
+  function handleAddStep(groupIdx: number) {
+    const nextStepIdx = stepGroups[groupIdx]?.steps.length ?? 0;
+
+    setStepGroups((draft) => {
+      const group = draft[groupIdx];
+      if (!group) {
+        return;
+      }
+      group.steps.push("");
+    });
+    setPendingFocus({ groupIdx, stepIdx: nextStepIdx });
+  }
+
+  function handleDeleteStep(groupIdx: number, stepIdx: number) {
+    setStepGroups((draft) => {
+      const group = draft[groupIdx];
+      if (!group) {
+        return;
+      }
+      group.steps.splice(stepIdx, 1);
+    });
+  }
+
+  function handleTitleChange(groupIdx: number, value: string) {
+    setStepGroups((draft) => {
+      const group = draft[groupIdx];
+      if (!group) {
+        return;
+      }
+      group.title = value;
+    });
   }
 
   function handleToggleDeleteGroup(groupIdx: number) {
-    setStepGroups(
-      produce((draft) => {
-        // set the ID to negative to indicate that it should be deleted
-        const group = draft[groupIdx];
+    setStepGroups((draft) => {
+      const group = draft[groupIdx];
 
-        if (!group) {
-          return;
-        }
+      if (!group) {
+        return;
+      }
 
-        // if it's a new group, just remove it
-        if (group.id === 0) {
-          draft.splice(groupIdx, 1);
-          return;
-        }
+      if (group.id === 0) {
+        draft.splice(groupIdx, 1);
+        return;
+      }
 
-        group.id = -group.id;
-      }),
-    );
+      group.id = -group.id;
+    });
   }
 
   function handleAddNewGroup() {
-    setStepGroups(
-      produce((draft) => {
-        const newGroup: StepGroup = {
-          id: 0,
-          title: "New group",
-          steps: ["New step"],
-          order: draft.length,
-          recipeId: -1,
-        };
-
-        draft.push(newGroup as any);
-      }),
-    );
+    setStepGroups((draft) => {
+      const recipeId = draft[0]?.recipeId ?? -1;
+      draft.push({
+        id: 0,
+        title: "New group",
+        steps: [""],
+        order: draft.length,
+        recipeId,
+      });
+    });
   }
 
   return (
-    <div className="w-full">
-      <div className="flex gap-1">
-        <Button onClick={handleSave}>
-          <Save />
-          Save
-        </Button>
-        {cancelButton}
-      </div>
+    <div className="w-full space-y-4">
       {stepGroups.map((group, groupIdx) => {
         const isDeleted = group.id < 0;
         const isNew = group.id === 0;
+        const originalGroup = getOriginalGroup(group);
+        const isTitleDirty =
+          originalGroup?.title !== undefined
+            ? group.title !== originalGroup.title
+            : group.title !== "New group";
+        const titleWidthCh = Math.max(8, group.title.trim().length + 1);
         return (
           <div
-            key={groupIdx}
+            key={group.id || groupIdx}
             className={cn(
-              { "bg-red-100 opacity-80": isDeleted },
-              { "bg-green-100 opacity-80": isNew },
-              "rounded-lg p-2",
+              "space-y-1.5 rounded-md bg-card/40",
+              isDeleted && "bg-red-100/50",
+              isNew && "bg-emerald-100/20",
             )}
           >
-            <div className="flex flex-col gap-1 md:flex-row">
+            <div className="flex items-center gap-1">
               <Input
+                id={`step-group-title-${group.id || groupIdx}`}
                 value={group.title}
-                className="text-lg font-bold"
+                className={cn(
+                  "h-10 w-auto max-w-[calc(100%-2.25rem)] rounded-sm bg-background/80 text-lg font-semibold",
+                  dirtyClass(isTitleDirty),
+                )}
+                style={{ width: `${titleWidthCh}ch` }}
                 onChange={(e) => handleTitleChange(groupIdx, e.target.value)}
-                placeholder="Group Title"
+                placeholder="Group title"
               />
-              <Button
-                onClick={() => handleToggleDeleteGroup(groupIdx)}
-                variant="destructive-outline"
-              >
-                <ListX />
-                Delete Group
-              </Button>
-            </div>
-            <ul className="flex list-inside list-decimal flex-col gap-2 p-2">
-              {group.steps.map((step, stepIdx) => (
-                <li
-                  key={stepIdx}
-                  className="ml-4 flex flex-col items-center gap-1 border-l-2 bg-gray-50 p-1 pl-4 md:flex-row"
+              <TooltipButton content={isDeleted ? "Restore group" : "Delete group"}>
+                <Button
+                  onClick={() => handleToggleDeleteGroup(groupIdx)}
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 rounded-sm text-destructive/80 hover:bg-destructive/10 hover:text-destructive"
                 >
+                  <Trash2 className="size-4 shrink-0" />
+                </Button>
+              </TooltipButton>
+            </div>
+
+            <div className="ml-2 space-y-2">
+              {group.steps.map((step, stepIdx) => {
+                const isStepDirty =
+                  originalGroup?.steps?.[stepIdx] !== undefined
+                    ? step !== originalGroup.steps[stepIdx]
+                    : step.trim().length > 0;
+
+                return (
+                <div
+                  key={`${group.id || groupIdx}-${stepIdx}`}
+                  className="grid grid-cols-[2.5rem_1fr_auto] items-start gap-2 rounded-sm bg-background/55 p-2"
+                >
+                  <div className="flex h-9 items-center justify-center rounded-sm bg-muted/40 text-sm font-semibold text-muted-foreground">
+                    {stepIdx + 1}
+                  </div>
                   <Textarea
+                    ref={(node) => {
+                      stepTextareaRefs.current[`${groupIdx}-${stepIdx}`] = node;
+                    }}
                     value={step}
                     onChange={(e) =>
                       handleStepChange(groupIdx, stepIdx, e.target.value)
                     }
                     autoResize
-                    className="w-full text-lg"
+                    rows={1}
+                    className={cn(
+                      "h-10 min-h-0 rounded-sm bg-background/80 text-base",
+                      dirtyClass(isStepDirty),
+                    )}
+                    placeholder="Describe this step"
                   />
-                  <Button
-                    onClick={() => handleDeleteStep(groupIdx, stepIdx)}
-                    variant="destructive-outline"
-                  >
-                    <Trash />
-                  </Button>
-                </li>
-              ))}
+                  <TooltipButton content="Delete step">
+                    <Button
+                      onClick={() => handleDeleteStep(groupIdx, stepIdx)}
+                      variant="ghost"
+                      size="icon"
+                      className="h-9 w-9 rounded-sm text-destructive/70 hover:bg-destructive/10 hover:text-destructive"
+                    >
+                      <Trash2 className="size-4 shrink-0" />
+                    </Button>
+                  </TooltipButton>
+                </div>
+                );
+              })}
+            </div>
 
-              <Button
-                className="ml-4 self-start"
-                onClick={() => handleAddStep(groupIdx)}
-              >
-                <Plus />
-                Add step
-              </Button>
-            </ul>
-
-            <Button onClick={handleAddNewGroup}>
-              <ListPlus />
-              Add New Group
+            <Button
+              className="ml-2 rounded-md"
+              onClick={() => handleAddStep(groupIdx)}
+              variant="secondary"
+            >
+              <Plus className="shrink-0" />
+              Add step
             </Button>
           </div>
         );
       })}
+
+      <Button onClick={handleAddNewGroup} className="rounded-md">
+        <FolderPlus className="shrink-0" />
+        Add New Group
+      </Button>
     </div>
   );
 }

--- a/src/app/recipes/[id]/StepListEditMode.tsx
+++ b/src/app/recipes/[id]/StepListEditMode.tsx
@@ -9,6 +9,7 @@ import { Textarea } from "~/components/ui/textarea";
 import { TooltipButton } from "~/components/ui/tooltip-button";
 import { cn } from "~/lib/utils";
 import { type Recipe } from "./recipe-types";
+import { dirtyInputClass } from "./edit-mode-utils";
 
 type StepGroups = Recipe["stepGroups"];
 
@@ -31,13 +32,6 @@ export function StepListEditMode(props: {
       return undefined;
     }
     return originalStepGroups.find((original) => original.id === group.id);
-  }
-
-  function dirtyClass(isDirty: boolean) {
-    return cn(
-      "transition-colors hover:bg-primary/10 focus-visible:bg-primary/10",
-      isDirty && "border border-primary/30 shadow-[0_1px_0_0_hsl(var(--primary)/0.2)]",
-    );
   }
 
   function setStepGroups(recipeUpdater: (draft: StepGroups) => void) {
@@ -160,13 +154,15 @@ export function StepListEditMode(props: {
                 value={group.title}
                 className={cn(
                   "h-10 w-auto max-w-[calc(100%-2.25rem)] rounded-sm bg-background/80 text-lg font-semibold",
-                  dirtyClass(isTitleDirty),
+                  dirtyInputClass(isTitleDirty),
                 )}
                 style={{ width: `${titleWidthCh}ch` }}
                 onChange={(e) => handleTitleChange(groupIdx, e.target.value)}
                 placeholder="Group title"
               />
-              <TooltipButton content={isDeleted ? "Restore group" : "Delete group"}>
+              <TooltipButton
+                content={isDeleted ? "Restore group" : "Delete group"}
+              >
                 <Button
                   onClick={() => handleToggleDeleteGroup(groupIdx)}
                   variant="ghost"
@@ -186,40 +182,41 @@ export function StepListEditMode(props: {
                     : step.trim().length > 0;
 
                 return (
-                <div
-                  key={`${group.id || groupIdx}-${stepIdx}`}
-                  className="grid grid-cols-[2.5rem_1fr_auto] items-start gap-2 rounded-sm bg-background/55 p-2"
-                >
-                  <div className="flex h-9 items-center justify-center rounded-sm bg-muted/40 text-sm font-semibold text-muted-foreground">
-                    {stepIdx + 1}
+                  <div
+                    key={`${group.id || groupIdx}-${stepIdx}`}
+                    className="grid grid-cols-[2.5rem_1fr_auto] items-start gap-2 rounded-sm bg-background/55 p-2"
+                  >
+                    <div className="flex h-9 items-center justify-center rounded-sm bg-muted/40 text-sm font-semibold text-muted-foreground">
+                      {stepIdx + 1}
+                    </div>
+                    <Textarea
+                      ref={(node) => {
+                        stepTextareaRefs.current[`${groupIdx}-${stepIdx}`] =
+                          node;
+                      }}
+                      value={step}
+                      onChange={(e) =>
+                        handleStepChange(groupIdx, stepIdx, e.target.value)
+                      }
+                      autoResize
+                      rows={1}
+                      className={cn(
+                        "h-10 min-h-0 rounded-sm bg-background/80 text-base",
+                        dirtyInputClass(isStepDirty),
+                      )}
+                      placeholder="Describe this step"
+                    />
+                    <TooltipButton content="Delete step">
+                      <Button
+                        onClick={() => handleDeleteStep(groupIdx, stepIdx)}
+                        variant="ghost"
+                        size="icon"
+                        className="h-9 w-9 rounded-sm text-destructive/70 hover:bg-destructive/10 hover:text-destructive"
+                      >
+                        <Trash2 className="size-4 shrink-0" />
+                      </Button>
+                    </TooltipButton>
                   </div>
-                  <Textarea
-                    ref={(node) => {
-                      stepTextareaRefs.current[`${groupIdx}-${stepIdx}`] = node;
-                    }}
-                    value={step}
-                    onChange={(e) =>
-                      handleStepChange(groupIdx, stepIdx, e.target.value)
-                    }
-                    autoResize
-                    rows={1}
-                    className={cn(
-                      "h-10 min-h-0 rounded-sm bg-background/80 text-base",
-                      dirtyClass(isStepDirty),
-                    )}
-                    placeholder="Describe this step"
-                  />
-                  <TooltipButton content="Delete step">
-                    <Button
-                      onClick={() => handleDeleteStep(groupIdx, stepIdx)}
-                      variant="ghost"
-                      size="icon"
-                      className="h-9 w-9 rounded-sm text-destructive/70 hover:bg-destructive/10 hover:text-destructive"
-                    >
-                      <Trash2 className="size-4 shrink-0" />
-                    </Button>
-                  </TooltipButton>
-                </div>
                 );
               })}
             </div>

--- a/src/app/recipes/[id]/edit-mode-utils.ts
+++ b/src/app/recipes/[id]/edit-mode-utils.ts
@@ -1,0 +1,9 @@
+import { cn } from "~/lib/utils";
+
+export function dirtyInputClass(isDirty: boolean) {
+  return cn(
+    "transition-colors hover:bg-primary/10 focus-visible:bg-primary/10",
+    isDirty &&
+      "border border-primary/30 shadow-[0_1px_0_0_hsl(var(--primary)/0.2)]",
+  );
+}


### PR DESCRIPTION
### Summary
- move the ingredient and step edit icons into the top-right corner of their respective cards and ensure the edit button position matches the provided mock
- add absolute-positioned plus icons between steps so inline inserts sit close to the step numbers without disrupting layout
- refresh supporting edit-mode utilities and API plumbing touched for these UI tweaks

### Testing
- Not run (not requested)